### PR TITLE
feat: POC RNF

### DIFF
--- a/clients/api-rnf/index.ts
+++ b/clients/api-rnf/index.ts
@@ -1,0 +1,79 @@
+import routes from '#clients/routes';
+import { IETATADMINSTRATIF } from '#models/etat-administratif';
+import { IFondation } from '#models/fondations';
+import { IdRnf } from '#utils/helpers/id-rnf';
+import { httpGet } from '#utils/network';
+
+type IRNFResponse = {
+  createdAt: string;
+  updatedAt: string;
+  rnfId: string; //"075-FDD-00003-01"
+  type: string;
+  department: string;
+  title: string;
+  dissolvedAt: string | null;
+  phone: string;
+  email: string;
+  address: {
+    createdAt: string;
+    updatedAt: string;
+    label: string;
+    type: string;
+    streetAddress: string;
+    streetNumber: string;
+    streetName: string;
+    postalCode: string;
+    cityName: string;
+    cityCode: string;
+    departmentName: string;
+    departmentCode: string;
+    regionName: string;
+    regionCode: string;
+  };
+  status: unknown;
+  persons: unknown[];
+};
+
+/**
+ * Call RNF API using an Id RNF
+ * @param idRnf
+ */
+const clientRNF = async (idRnf: IdRnf, useCache = true) => {
+  const url = `${routes.rnf}${idRnf}`;
+  const response = await httpGet<IRNFResponse>(url, { useCache });
+
+  return mapToDomainObject(idRnf, response);
+};
+
+const mapToDomainObject = (
+  idRnf: IdRnf,
+  response: IRNFResponse
+): IFondation => {
+  const {
+    title,
+    dissolvedAt,
+    address,
+    department,
+    type,
+    createdAt,
+    phone,
+    email,
+  } = response;
+
+  return {
+    idRnf,
+    nomComplet: title,
+    etatAdministratif: !dissolvedAt
+      ? IETATADMINSTRATIF.ACTIF
+      : IETATADMINSTRATIF.CESSEE,
+    adresse: address.label,
+    departement: department,
+    type,
+    dateCreation: createdAt.split('T')[0],
+    dateFermeture: (dissolvedAt || '').split('T')[0],
+    telephone: phone,
+    email,
+  };
+};
+
+export { clientRNF };

--- a/clients/routes.ts
+++ b/clients/routes.ts
@@ -53,6 +53,7 @@ const routes = {
       'https://geo.api.gouv.fr/departements?fields=code&format=json&zone=metro,drom,com',
     region: 'https://geo.api.gouv.fr/regions?limit=3',
   },
+  rnf: 'https://rnf.dso.numerique-interieur.com/api/foundations/',
   journalOfficielAssociations: {
     ods: {
       metadata:

--- a/components-ui/badge/frequent.tsx
+++ b/components-ui/badge/frequent.tsx
@@ -34,6 +34,23 @@ export const AssociationBadge = ({
     backgroundColor="#e5d2f9"
   />
 );
+
+export const FondationBadge = ({
+  small = false,
+  isSelected = false,
+  onClick,
+}: IPartialBadgeProps) => (
+  <Badge
+    small={small}
+    onClick={onClick}
+    icon="communityFill"
+    isSelected={isSelected}
+    label="Fondation"
+    fontColor="#3d0d71"
+    backgroundColor="#ffb8e3"
+  />
+);
+
 export const EntrepriseIndividuelleBadge = ({
   small = false,
   isSelected = false,

--- a/models/fondations/index.ts
+++ b/models/fondations/index.ts
@@ -1,0 +1,43 @@
+import { clientRNF } from '#clients/api-rnf';
+import { HttpNotFound } from '#clients/exceptions';
+import { IETATADMINSTRATIF } from '#models/etat-administratif';
+import { IdRnf, verifyIdRnf } from '#utils/helpers/id-rnf';
+import logErrorInSentry from '#utils/sentry';
+import { NotAnIdRnfError, RnfNotFoundError } from '..';
+
+export type IFondation = {
+  idRnf: IdRnf;
+  etatAdministratif: IETATADMINSTRATIF;
+  nomComplet: string;
+  adresse: string;
+  departement: string;
+  type: string;
+  dateCreation: string;
+  dateFermeture: string;
+  telephone: string;
+  email: string;
+};
+
+/**
+ * Get a fondation if it exists
+ * @param slug
+ * @returns
+ */
+export const getFondationFromSlug = async (slug: string) => {
+  try {
+    const idRnf = verifyIdRnf(slug);
+    return await clientRNF(idRnf);
+  } catch (e: any) {
+    if (e instanceof HttpNotFound) {
+      throw new RnfNotFoundError(slug);
+    } else if (e instanceof NotAnIdRnfError) {
+      throw e;
+    }
+
+    logErrorInSentry(e, {
+      details: slug,
+      errorName: 'Error in API RNF',
+    });
+    throw e;
+  }
+};

--- a/models/immatriculation/joafe.ts
+++ b/models/immatriculation/joafe.ts
@@ -8,7 +8,7 @@ import {
 import { IdRna, Siren, verifyIdRna } from '#utils/helpers';
 import logErrorInSentry from '#utils/sentry';
 import { IImmatriculation } from '.';
-import { NotAValidIdRnaError } from '..';
+import { NotAnIdRnaError } from '..';
 
 export interface IImmatriculationJOAFE extends IImmatriculation {
   siren: Siren;
@@ -41,7 +41,7 @@ export const getImmatriculationJOAFE = async (
       siteLink: annonceCreation.path,
     } as IImmatriculationJOAFE;
   } catch (e: any) {
-    if (e instanceof HttpNotFound || e instanceof NotAValidIdRnaError) {
+    if (e instanceof HttpNotFound || e instanceof NotAnIdRnaError) {
       return APINotRespondingFactory(EAdministration.DILA, 404);
     }
 

--- a/models/index.ts
+++ b/models/index.ts
@@ -318,7 +318,31 @@ export class NotASiretError extends Error {
 /**
  * This is not a valid IdRna
  */
-export class NotAValidIdRnaError extends Error {
+export class NotAnIdRnaError extends Error {
+  constructor(public message: string) {
+    super();
+  }
+}
+
+/**
+ * This is not a valid IdRnf
+ */
+export class NotAnIdRnfError extends Error {
+  constructor(public message: string) {
+    super();
+  }
+}
+
+/**
+ * This is a valid siren but it was not found
+ */
+export class RnfNotFoundError extends Error {
+  constructor(public message: string) {
+    super();
+  }
+}
+
+export class IsLikelyAnIdRnfException extends Error {
   constructor(public message: string) {
     super();
   }

--- a/pages/fondation/[slug].tsx
+++ b/pages/fondation/[slug].tsx
@@ -1,0 +1,115 @@
+import { GetServerSideProps } from 'next';
+import { FondationBadge } from '#components-ui/badge/frequent';
+import { HorizontalSeparator } from '#components-ui/horizontal-separator';
+import IsActiveTag from '#components-ui/is-active-tag';
+import Meta from '#components/meta';
+import { DataSection } from '#components/section/data-section';
+import { TwoColumnTable } from '#components/table/simple';
+import { EAdministration } from '#models/administrations';
+import { IFondation, getFondationFromSlug } from '#models/fondations';
+import { ISTATUTDIFFUSION } from '#models/statut-diffusion';
+import { formatDate, formatIntFr } from '#utils/helpers';
+import { libelleFromDepartement } from '#utils/helpers/formatting/labels';
+import extractParamsFromContext from '#utils/server-side-props-helper/extract-params-from-context';
+import {
+  IPropsWithMetadata,
+  postServerSideProps,
+} from '#utils/server-side-props-helper/post-server-side-props';
+import { NextPageWithLayout } from 'pages/_app';
+
+interface IProps extends IPropsWithMetadata {
+  fondation: IFondation;
+}
+
+const FondationPage: NextPageWithLayout<IProps> = ({ fondation }) => (
+  <>
+    <Meta
+      title={fondation.nomComplet}
+      noIndex={true}
+      canonical={`https://annuaire-entreprises.data.gouv.fr/fondation/${fondation.idRnf}`}
+    />
+
+    <h1>{fondation.nomComplet}</h1>
+    <div className="fondation-sub-title">
+      <FondationBadge />
+      <span className="siren">&nbsp;‣&nbsp;{formatIntFr(fondation.idRnf)}</span>
+      <span>
+        <IsActiveTag
+          etatAdministratif={fondation.etatAdministratif}
+          statutDiffusion={ISTATUTDIFFUSION.DIFFUSIBLE}
+        />
+      </span>
+    </div>
+
+    <div className="content-container">
+      <DataSection
+        title="Répertoire National des fondations"
+        sources={[EAdministration.MI]}
+        data={fondation}
+      >
+        {(fondation) => (
+          <>
+            <TwoColumnTable
+              body={[
+                ['N°RNF', fondation.idRnf],
+                ['Nom', fondation.nomComplet],
+                [
+                  'Département',
+                  `${libelleFromDepartement(fondation.departement)} (${
+                    fondation.departement
+                  })`,
+                ],
+                ['Adresse', fondation.adresse],
+                ['Date de création', formatDate(fondation.dateCreation)],
+                ...(fondation.dateFermeture
+                  ? [['Date de fermeture', formatDate(fondation.dateCreation)]]
+                  : []),
+                [
+                  'Téléphone',
+                  fondation.telephone ? (
+                    <a href={`tel:${fondation.telephone}`}>
+                      {fondation.telephone}
+                    </a>
+                  ) : (
+                    ''
+                  ),
+                ],
+                [
+                  'Email',
+                  fondation.email ? (
+                    <a href={`mailto:${fondation.email}`}>{fondation.email}</a>
+                  ) : (
+                    ''
+                  ),
+                ],
+              ]}
+            />
+          </>
+        )}
+      </DataSection>
+    </div>
+    <HorizontalSeparator />
+    <style jsx>{`
+      .fondation-sub-title {
+        display: flex;
+        align-items: center;
+      }
+    `}</style>
+  </>
+);
+
+export const getServerSideProps: GetServerSideProps = postServerSideProps(
+  async (context) => {
+    const { slug } = extractParamsFromContext(context, true);
+
+    const fondation = await getFondationFromSlug(slug);
+
+    return {
+      props: {
+        fondation,
+      },
+    };
+  }
+);
+
+export default FondationPage;

--- a/utils/helpers/id-rna.ts
+++ b/utils/helpers/id-rna.ts
@@ -1,4 +1,4 @@
-import { NotAValidIdRnaError } from '#models/index';
+import { NotAnIdRnaError } from '#models/index';
 
 /**
  * IdRna types
@@ -21,11 +21,11 @@ export const isIdRna = (slug: string): slug is IdRna => {
 };
 
 /**
- * Throw an exception if a string is not a siret
+ * Throw an exception if a string is not a RNA
  * */
 export const verifyIdRna = (slug: string): IdRna => {
   if (!slug || !isIdRna(slug)) {
-    throw new NotAValidIdRnaError(slug);
+    throw new NotAnIdRnaError(slug);
   }
   return slug;
 };

--- a/utils/helpers/id-rnf.test.ts
+++ b/utils/helpers/id-rnf.test.ts
@@ -1,0 +1,14 @@
+import { isIdRnfValid } from './id-rnf';
+
+describe('Check isIdRna', () => {
+  test('Succeed with valid RNF', () => {
+    expect(isIdRnfValid('075-FDD-00003-01')).toBe(true);
+  });
+  test('Fails with invalid RNA', () => {
+    expect(isIdRnfValid('97-184')).toBe(false);
+    expect(isIdRnfValid('353019855')).toBe(false);
+    expect(isIdRnfValid('37_2304')).toBe(false);
+  });
+});
+
+export {};

--- a/utils/helpers/id-rnf.ts
+++ b/utils/helpers/id-rnf.ts
@@ -1,0 +1,31 @@
+import { NotAnIdRnfError } from '#models/index';
+
+/**
+ * IdRnf types
+ */
+type Brand<K, T> = K & { __brand: T };
+
+export type IdRnf = Brand<string, 'IdRnf'>;
+
+/**
+ * Two valid Id RNF format
+ */
+const matchFormat = (str: string) =>
+  !!str.match(/^0\d{2}-[a-zA-Z]{3}-\d{5}-\d{2}$/);
+
+export const isIdRnfValid = (slug: string): slug is IdRnf => {
+  if (matchFormat(slug)) {
+    return true;
+  }
+  return false;
+};
+
+/**
+ * Throw an exception if a string is not a RNF
+ * */
+export const verifyIdRnf = (slug: string): IdRnf => {
+  if (!slug || !isIdRnfValid(slug)) {
+    throw new NotAnIdRnfError(slug);
+  }
+  return slug;
+};

--- a/utils/server-side-props-helper/error-handler.ts
+++ b/utils/server-side-props-helper/error-handler.ts
@@ -3,16 +3,22 @@ import { GetServerSidePropsContext } from 'next';
 import { HttpNotFound } from '#clients/exceptions';
 import {
   IsLikelyASirenOrSiretException,
+  IsLikelyAnIdRnfException,
   NotASirenError,
   NotASiretError,
+  NotAnIdRnfError,
   NotLuhnValidSirenError,
   NotLuhnValidSiretError,
+  RnfNotFoundError,
   SearchEngineError,
   SirenNotFoundError,
   SiretNotFoundError,
 } from '#models/index';
 import { verifySiren, verifySiret } from '#utils/helpers';
 import {
+  redirectIdRnfIntrouvable,
+  redirectIdRnfInvalid,
+  redirectIfIdRnf,
   redirectIfSiretOrSiren,
   redirectPageNotFound,
   redirectSearchEngineError,
@@ -43,6 +49,12 @@ const handleExceptions = (exception: any, req: IncomingMessage | undefined) => {
       exception instanceof NotASiretError
     ) {
       return redirectPageNotFound(message, scope);
+    } else if (exception instanceof IsLikelyAnIdRnfException) {
+      return redirectIfIdRnf(message);
+    } else if (exception instanceof NotAnIdRnfError) {
+      return redirectIdRnfInvalid(message);
+    } else if (exception instanceof RnfNotFoundError) {
+      return redirectIdRnfIntrouvable(message);
     } else if (exception instanceof HttpNotFound) {
       return redirectPageNotFound(message, scope);
     } else if (exception instanceof SearchEngineError) {

--- a/utils/server-side-props-helper/redirects.ts
+++ b/utils/server-side-props-helper/redirects.ts
@@ -91,7 +91,7 @@ export const redirectIdRnfIntrouvable = (idRnf: string, scope?: IScope) => {
 };
 
 export const redirectIdRnfInvalid = (idRnf: string, scope?: IScope) => {
-  logWarningInSentry('Redirect siren or siret invalid', scope);
+  logWarningInSentry('Redirect idRnf invalid', scope);
   return {
     redirect: {
       destination: `/erreur/invalide/${idRnf}`,

--- a/utils/server-side-props-helper/redirects.ts
+++ b/utils/server-side-props-helper/redirects.ts
@@ -71,6 +71,35 @@ export const redirectSirenOrSiretIntrouvable = (
   };
 };
 
+export const redirectIfIdRnf = (slug: string) => {
+  return {
+    redirect: {
+      destination: `/fondation/${slug}`,
+      permanent: false,
+    },
+  };
+};
+
+export const redirectIdRnfIntrouvable = (idRnf: string, scope?: IScope) => {
+  logWarningInSentry('Redirect Id RNF not found', scope);
+  return {
+    redirect: {
+      destination: `/erreur/introuvable/${idRnf}`,
+      permanent: false,
+    },
+  };
+};
+
+export const redirectIdRnfInvalid = (idRnf: string, scope?: IScope) => {
+  logWarningInSentry('Redirect siren or siret invalid', scope);
+  return {
+    redirect: {
+      destination: `/erreur/invalide/${idRnf}`,
+      permanent: false,
+    },
+  };
+};
+
 export const redirectIfSiretOrSiren = (siretOrSiren: string) => {
   let destination;
   if (hasSiretFormat(siretOrSiren)) {


### PR DESCRIPTION
## Context

The MI is currently working on a new DB called RNF (Répertoire National des Fondations). 

They needs a platform to : 
- execute full text search
- access DB

## Current scope 

First implementation of RNF : 
- only handle redirection of a valid RNF Id to a dedicated page `/fondation/<ID_RNF>`
- only works on preprod for a given ID `075-FDD-00003-01`
- do not allow full text search (need stock and actual data first)

## Next steps : 
- [ ] share review app with MI team
- [ ] ask the MI team what is the real ID RNF format mask
- [ ] update the `Invalid` / `Not found` workflows

closes #731