### PR TITLE
fix: disable sourcemap upload when sentry is down

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,19 @@
 const { withSentryConfig } = require("@sentry/nextjs");
 const redirects = require('./redirects.json');
 
+const WITH_SENTRY = process.env.NEXT_PUBLIC_SENTRY_DSN && process.env.NODE_ENV === "production";
+const DISABLE_SOURCEMAP_UPLOAD = process.env.SENTRY_DISABLE_SOURCEMAP_UPLOAD === "true";
+
+if (DISABLE_SOURCEMAP_UPLOAD) {
+  console.warn(`
+  
+--------------------------------------------------------
+WARNING: Building without uploading sourcemap to Sentry
+(probably because https://errors.data.gouv.fr is down)
+--------------------------------------------------------
+
+`)
+}
 const nextjsConfig = {
   webpack: function (config) {
     config.module.rules.push({
@@ -12,13 +25,19 @@ const nextjsConfig = {
   async redirects() {
     return redirects;
   },
-  sentry: {
-    widenClientFileUpload: true,
-  },
+  ...(WITH_SENTRY ? {
+    sentry: {
+      widenClientFileUpload: true,
+      ...(DISABLE_SOURCEMAP_UPLOAD ? {
+        disableServerWebpackPlugin: true,
+        disableClientWebpackPlugin: true,
+      } : {}),
+    }
+  } : {}),
 }
 
 
-module.exports = process.env.NODE_ENV === "production" && process.env.NEXT_PUBLIC_SENTRY_DSN
+module.exports = WITH_SENTRY
   ? withSentryConfig(nextjsConfig, { silent: true, hideSourceMaps: false, ignore: [] })
   : nextjsConfig;
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "dev": "run-p start:dev:*",
     "build:clean": "if [ -d 'public/assets' ]; then rm -Rf public/assets; fi",
     "build:frontend": "npm run build:clean && NODE_ENV=production vite build frontend --config ./frontend/vite.config.ts",
-    "build:back": "NODE_ENV=production next build",
+    "build:back": "NODE_ENV=production next build || NODE_ENV=production SENTRY_DISABLE_SOURCEMAP_UPLOAD=true next build",
     "build": "npm run build:frontend && npm run build:back",
     "start": "NODE_ENV=production && next start",
     "test:end2end:run:mock": "END2END_MOCKING=enabled run-p dev test:end2end:run",


### PR DESCRIPTION
Retry to build the app without uploading sourcemaps when sentry is down, to prevent deploy from being blocked.
