### PR TITLE
fix: only rely on DGEFP for qualiopi certification

### DIFF
--- a/clients/open-data-soft/clients/qualiopi/index.ts
+++ b/clients/open-data-soft/clients/qualiopi/index.ts
@@ -23,6 +23,7 @@ const clientOrganismeFormation = async (
   const fields = response.records as IOrganismesFormationRecord[];
   return {
     records: fields.map(mapToDomainObject),
+    estQualiopi: !!fields.find((f) => (f?.certifications || []).length > 0),
     lastModified: response.lastModified,
   };
 };

--- a/components/labels-and-certificates/organismes-de-formation/index.tsx
+++ b/components/labels-and-certificates/organismes-de-formation/index.tsx
@@ -17,73 +17,76 @@ export const OrganismeDeFormationSection = ({
   organismesDeFormation,
   uniteLegale,
 }: OrganismeDeFormationSectionProps) => {
-  const estQualiopi = uniteLegale.complements.estQualiopi;
-
-  const head = [
-    'Numéro Déclaration Activité (NDA)',
-    'Détails',
-    ...(estQualiopi ? ['Certification(s) Qualiopi'] : []),
-  ];
-
-  const title = `Organisme de formation${
-    estQualiopi ? ' certifié Qualiopi' : ''
-  }`;
-
   return (
     <DataSection
-      title={title}
+      title="Organisme de formation"
       sources={[EAdministration.MTPEI]}
       id="organisme-de-formation"
       data={organismesDeFormation}
-      notFoundInfo={<OrganismeFormationLabel estQualiopi={estQualiopi} />}
+      // if 404 from DGEFP we can assume this organism is NOT qualiopi
+      notFoundInfo={<OrganismeFormationLabel estQualiopi={false} />}
     >
-      {(organismesDeFormation) => (
-        <>
-          <OrganismeFormationLabel estQualiopi={estQualiopi} />
-          <FullTable
-            head={head}
-            body={organismesDeFormation.records.map((fields) => [
-              <Tag>{fields.nda ? fields.nda : 'Inconnu'}</Tag>,
-              <>
-                {fields.specialite && (
-                  <>
-                    <strong>Spécialité :</strong> {fields.specialite}
-                    <br />
-                  </>
-                )}
-                {fields.formateurs && (
-                  <>
-                    <strong>Effectifs formateurs :</strong> {fields.formateurs}
-                    <br />
-                  </>
-                )}
-                {fields.stagiaires && (
-                  <>
-                    <strong>Effectifs stagiaires :</strong> {fields.stagiaires}
-                    <br />
-                  </>
-                )}
-                {fields.dateDeclaration && (
-                  <>
-                    <strong>Déclaration : </strong> le {fields.dateDeclaration}
-                    {fields.region && <>, en région {fields.region}</>}
-                    <br />
-                  </>
-                )}
-              </>,
-              ...(estQualiopi
-                ? [
-                    fields.certifications.map((certification) => (
-                      <Tag color="info" key={certification}>
-                        {certification}
-                      </Tag>
-                    )),
-                  ]
-                : []),
-            ])}
-          />{' '}
-        </>
-      )}
+      {(organismesDeFormation) => {
+        // we use definition from DGEFP rather than recherche entreprise which can be outdated
+        const estQualiopi = organismesDeFormation.estQualiopi;
+
+        const head = [
+          'Numéro Déclaration Activité (NDA)',
+          'Détails',
+          ...(estQualiopi ? ['Certification(s) Qualiopi'] : []),
+        ];
+
+        return (
+          <>
+            <OrganismeFormationLabel estQualiopi={estQualiopi} />
+            <FullTable
+              head={head}
+              body={organismesDeFormation.records.map((fields) => [
+                <Tag>{fields.nda ? fields.nda : 'Inconnu'}</Tag>,
+                <>
+                  {fields.specialite && (
+                    <>
+                      <strong>Spécialité :</strong> {fields.specialite}
+                      <br />
+                    </>
+                  )}
+                  {fields.formateurs && (
+                    <>
+                      <strong>Effectifs formateurs :</strong>{' '}
+                      {fields.formateurs}
+                      <br />
+                    </>
+                  )}
+                  {fields.stagiaires && (
+                    <>
+                      <strong>Effectifs stagiaires :</strong>{' '}
+                      {fields.stagiaires}
+                      <br />
+                    </>
+                  )}
+                  {fields.dateDeclaration && (
+                    <>
+                      <strong>Déclaration : </strong> le{' '}
+                      {fields.dateDeclaration}
+                      {fields.region && <>, en région {fields.region}</>}
+                      <br />
+                    </>
+                  )}
+                </>,
+                ...(estQualiopi
+                  ? [
+                      fields.certifications.map((certification) => (
+                        <Tag color="info" key={certification}>
+                          {certification}
+                        </Tag>
+                      )),
+                    ]
+                  : []),
+              ])}
+            />{' '}
+          </>
+        );
+      }}
     </DataSection>
   );
 };

--- a/models/certifications/organismes-de-formation.ts
+++ b/models/certifications/organismes-de-formation.ts
@@ -20,6 +20,7 @@ export type IOrganismeFormation = {
     dateDeclaration: string | null;
     region: string | null;
   }[];
+  estQualiopi: boolean;
   lastModified: string | null;
 };
 


### PR DESCRIPTION
In addition to more frequent dataset update on recherche-entreprise side, this PR made a change in Organisme de Formation section. 

We now only rely on DGEFP response to determine if an organisme is Qualiopi as recherche entreprise can be outdated.

This mean we loose the ability to have "certifié qualiopi" in the section title, but this seem like a fair trade off.

We will still have outdated data in summary and in the search engine so this will not entirely solve the issue, but it will improve it.