### PR TITLE
feat: create a not found default page

### DIFF
--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,17 @@
+import { ErrorNotFoundExplanations } from '#components/error-explanations';
+import Footer from '#components/footer';
+import { HeaderServer } from '#components/header/header-server';
+import QuestionOrFeedback from './_component/question-or-feedback';
+
+export default function NotFound() {
+  return (
+    <>
+      <HeaderServer useSearchBar={true} useAgentCTA={true} />
+      <main className="fr-container">
+        <ErrorNotFoundExplanations />
+      </main>
+      <QuestionOrFeedback session={null} />
+      <Footer />
+    </>
+  );
+}


### PR DESCRIPTION
@johangirod I feel this is better than current default page https://annuaire-entreprises.data.gouv.fr/sources-de-donnees

I think the same should be done for 500 but I did not fully understand how global-error.tsx and other error.tsx interacts and I dont want to break it 