### PR TITLE
fix: typo in codes-NAF-rev-2.ts

### DIFF
--- a/utils/helpers/formatting/metadata/codes-NAF-rev-2.ts
+++ b/utils/helpers/formatting/metadata/codes-NAF-rev-2.ts
@@ -727,7 +727,7 @@ export const codesNAFRev2 = {
   '77.39Z':
     'Location et location-bail d’autres machines, équipements et biens matériels n.c.a.',
   '77.40Z':
-    'Location-bail de propriété intellectuelle et de produits similaires, à l’exception des œuvres soumises à ,copyright',
+    'Location-bail de propriété intellectuelle et de produits similaires, à l’exception des œuvres soumises à copyright',
   '78.10Z': 'Activités des agences de placement de main-d’œuvre',
   '78.20Z': 'Activités des agences de travail temporaire',
   '78.30Z': 'Autre mise à disposition de ressources humaines',


### PR DESCRIPTION
- Correction d'un bug | Changement mineur.
- Zones impactées : `utils/helpers/formatting/metadata/codes-NAF-rev-2.ts`.
- Détails :
  - Correction d’une **faute de frappe** (une virgule en trop) dans un des libellés de la NAFv2 (Nomenclature d’Activités Française).
  - Une page où la faute apparaît : https://annuaire-entreprises.data.gouv.fr/entreprise/l-oreal-interbeauty-632012100
 
Le message du commit :
> Label for NAFv2 code 77.40Z was :
> « Location-bail de propriété intellectuelle et de produits similaires, à l’exception des œuvres soumises **à ,copyright** »  
> Notice the superfluous comma before «copyright».
> 
> This commit removes that comma. 
> 
> References:
> 
> - https://www.insee.fr/fr/metadonnees/nafr2/sousClasse/77.40z : has the correct label 
> - https://annuaire-entreprises.data.gouv.fr/entreprise/l-oreal-interbeauty-632012100 : for instance, the extra comma surfaces here
