### PR TITLE
feat: responsive and first date

### DIFF
--- a/components/header/changelog-notification.module.css
+++ b/components/header/changelog-notification.module.css
@@ -2,7 +2,7 @@
   content: '';
   position: absolute;
   top: 5px;
-  right: 5px;
+  right: 2px;
   width: 10px;
   height: 10px;
   background-color: #ff0000;
@@ -11,6 +11,14 @@
 }
 
 .changelogNotification {
-  top: -2px;
   position: relative;
+}
+
+@media only screen and (min-width: 1px) and (max-width: 992px) {
+  .notificationText {
+    display: none;
+  }
+  .changelogNotification::before {
+    top: 0;
+  }
 }

--- a/components/header/changelog-notification.tsx
+++ b/components/header/changelog-notification.tsx
@@ -1,14 +1,13 @@
 'use client';
 
 import { useEffect } from 'react';
-import FadeIn from '#components-ui/animation/fade-in';
 import { Icon } from '#components-ui/icon/wrapper';
-import InformationTooltip from '#components-ui/information-tooltip';
 import { changelogData } from '#models/historique-modifications';
 import { EScope, hasRights } from '#models/user/rights';
+import { formatDate } from '#utils/helpers';
 import { useStorage } from 'hooks';
 import useSession from 'hooks/use-session';
-import style from './nouveautes-badge.module.css';
+import style from './changelog-notification.module.css';
 
 const NEW_SINCE_LAST_VISIT_ID = 'new-since-last-visit';
 const siteChangelog = changelogData.filter(
@@ -31,7 +30,7 @@ export default function ChangelogNotification() {
   const [previousDateOfLastNews, saveDateOfLastNews] = useStorage(
     'local',
     NEW_SINCE_LAST_VISIT_ID,
-    dateOfLastNews
+    null
   );
 
   useEffect(() => {
@@ -40,32 +39,27 @@ export default function ChangelogNotification() {
     }
   }, []);
 
+  if (!previousDateOfLastNews) {
+    saveDateOfLastNews(formatDate(new Date()));
+  }
+
   if (
-    !dateOfLastNews ||
     !previousDateOfLastNews ||
+    !dateOfLastNews ||
     convertToISO(previousDateOfLastNews) >= convertToISO(dateOfLastNews)
   ) {
     return null;
   }
 
   return (
-    <li>
-      <FadeIn>
-        <InformationTooltip
-          verticalOrientation="bottom"
-          label="Découvrir les nouveautés"
-          width={200}
-          tabIndex={undefined}
-          ariaRelation="labelledby"
-        >
-          <a
-            href="/historique-des-modifications"
-            className={style.changelogNotification + ' fr-btn  fr-btn--sm'}
-          >
-            <Icon slug="present" />
-          </a>
-        </InformationTooltip>
-      </FadeIn>
-    </li>
+    <a
+      href="/historique-des-modifications"
+      className={style.changelogNotification + ' fr-link'}
+      title="Découvrir les dernières évolutions de l’Annuaire des Entreprises"
+    >
+      <Icon slug="present">
+        <span className={style.notificationText}>Nouveautés</span>
+      </Icon>
+    </a>
   );
 }

--- a/components/header/header-core/index.tsx
+++ b/components/header/header-core/index.tsx
@@ -97,6 +97,7 @@ export const HeaderCore: React.FC<IProps> = ({
                         </div>
                       ) : null}
                       <div className={styles.menuMobile}>
+                        <ChangelogNotificationWithoutSSR />
                         <Menu
                           session={session}
                           useAgentCTA={useAgentCTA}
@@ -113,7 +114,9 @@ export const HeaderCore: React.FC<IProps> = ({
                   <div className="fr-header__tools">
                     <div className="fr-header__tools-links">
                       <ul className="fr-links-group">
-                        <ChangelogNotificationWithoutSSR />
+                        <li>
+                          <ChangelogNotificationWithoutSSR />
+                        </li>
                         <li>
                           <Menu
                             session={session}

--- a/components/header/header-core/styles.module.css
+++ b/components/header/header-core/styles.module.css
@@ -18,6 +18,8 @@
   order: 3;
   padding: 1rem;
   margin-left: auto;
+  gap: 1rem;
+  display: flex;
 }
 
 @media screen and (min-width: 993px) {

--- a/hooks/use-storage.ts
+++ b/hooks/use-storage.ts
@@ -1,14 +1,34 @@
 import { useState } from 'react';
 
+function isStorageAvailable(type: 'session' | 'local') {
+  const test = 'test';
+  const store =
+    type === 'session' ? window.sessionStorage : window.localStorage;
+
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  try {
+    store.setItem(test, test);
+    store.removeItem(test);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
 export const useStorage = (
   type: 'session' | 'local',
   key: string,
   initialValue: any
 ) => {
+  const storageAvailable = isStorageAvailable(type);
+
   // State to store our value
   // Pass initial state function to useState so logic is only executed once
   const [storedValue, setStoredValue] = useState(() => {
-    if (typeof window === 'undefined') {
+    if (!storageAvailable) {
       return initialValue;
     }
 
@@ -24,6 +44,10 @@ export const useStorage = (
       return initialValue;
     }
   });
+
+  if (!storageAvailable) {
+    return [storedValue, () => {}];
+  }
 
   // Return a wrapped version of useState's setter function that ...
   // ... persists the new value to localStorage.


### PR DESCRIPTION
@johangirod I tried to fix some issues, here are some propositions : 
- rename nouveautés into changelog-notification as it is tied to the changelog logic
- add an initialization date to target visitors that never visited `/historique...`
- responsiveness : I had to fought the header a bit to find a way to make it responsive. Unfortunately I had to remove `<FadeIn />` and the `tooltip` but it turns out that a label on desktop works pretty well (like on DS), and just the Icon on mobile is consistent with the menu icon
- add a early return on `useStorage` when storage is not available

<img width="1273" alt="image" src="https://github.com/user-attachments/assets/2d9904ad-667f-4e24-be66-678a2958874a">

<img width="492" alt="image" src="https://github.com/user-attachments/assets/cef306fd-bd66-4ea4-9825-0b750da53656">

I really like the icon and the little red dot, catchy but elegant !