### PR TITLE
Revert "fix: stop calling grist"

### DIFF
--- a/pages/a-propos/stats.tsx
+++ b/pages/a-propos/stats.tsx
@@ -1,5 +1,5 @@
 import { GetStaticProps } from 'next';
-import { IMatomoStats } from '#clients/matomo';
+import { IMatomoStats, clientMatomoStats } from '#clients/matomo';
 import Meta from '#components/meta/meta-client';
 import { NpsStats } from '#components/stats/nps';
 import { TraficStats } from '#components/stats/trafic';
@@ -40,22 +40,22 @@ const StatsPage: NextPageWithLayout<IMatomoStats> = ({
 );
 
 export const getStaticProps: GetStaticProps = async () => {
-  // const {
-  //   visits,
-  //   monthlyNps,
-  //   userResponses,
-  //   mostCopied,
-  //   copyPasteAction,
-  //   redirectedSiren,
-  // } = await clientMatomoStats();
+  const {
+    visits,
+    monthlyNps,
+    userResponses,
+    mostCopied,
+    copyPasteAction,
+    redirectedSiren,
+  } = await clientMatomoStats();
   return {
     props: {
-      monthlyNps: [],
-      visits: [],
-      userResponses: [],
-      mostCopied: [],
-      copyPasteAction: [],
-      redirectedSiren: [],
+      monthlyNps,
+      visits,
+      userResponses,
+      mostCopied,
+      copyPasteAction,
+      redirectedSiren,
     },
     revalidate: 4 * 3600, // In seconds - 4 hours
   };

--- a/utils/integrations/grist.ts
+++ b/utils/integrations/grist.ts
@@ -47,7 +47,6 @@ export async function logInGrist(
   tableKey: keyof typeof gristTables,
   data: unknown[]
 ) {
-  return;
   await httpClient({
     method: 'POST',
     url: getGristUrl(tableKey),
@@ -65,7 +64,6 @@ export async function logInGrist(
 }
 
 export async function readFromGrist(tableKey: keyof typeof gristTables) {
-  return [];
   const { records } = await httpClient<IGristRecords>({
     method: 'GET',
     url: getGristUrl(tableKey),


### PR DESCRIPTION
Bug report : 23/09 
- GRIST stopped taking new calls, returns 429 and `{"error": "Too many backlogged requests for document XXXXXX - try again later?}` on any route/resource
- 797a190e027dd7792be40c904959832d87916285 stopped log connexion on `Logs_connexion`
- 2eec0b81c1ebe89505d04976a26f57d142c6dce9 stopped ALL call (read/write) to grist
- GRIST still blocked at `Too many backlogged requests for document `