### PR TITLE
fix: suppression insee et recherche entreprise nom commercial

### DIFF
--- a/clients/sirene-insee/helpers.ts
+++ b/clients/sirene-insee/helpers.ts
@@ -1,0 +1,10 @@
+/**
+ * When a company removes a commercial name,
+ * INSEE sets its old "denomination usuelle" to "SUPPRESSION DU NOM COMMERCIAL".
+ * This function removes that specific mention.
+ */
+export const formatDenominationUsuelle = (denominationUsuelle: string) => {
+  return denominationUsuelle !== 'SUPPRESSION DU NOM COMMERCIAL'
+    ? denominationUsuelle
+    : '';
+};

--- a/clients/sirene-insee/siren.ts
+++ b/clients/sirene-insee/siren.ts
@@ -27,6 +27,7 @@ import {
   parseDateCreationInsee,
   statuDiffusionFromStatutDiffusionInsee,
 } from '../../utils/helpers/insee-variables';
+import { formatDenominationUsuelle } from './helpers';
 import {
   clientAllEtablissementsInsee,
   clientEtablissementInsee,
@@ -207,9 +208,9 @@ const mapToDomainObject = (
   const denominationUsuelleUniteLegale =
     siege.denomination ||
     agregateTripleFields(
-      denominationUsuelle1UniteLegale,
-      denominationUsuelle2UniteLegale,
-      denominationUsuelle3UniteLegale
+      formatDenominationUsuelle(denominationUsuelle1UniteLegale),
+      formatDenominationUsuelle(denominationUsuelle2UniteLegale),
+      formatDenominationUsuelle(denominationUsuelle3UniteLegale)
     ) ||
     '';
 


### PR DESCRIPTION
- Correction d'un bug
- Zones impactées : `./models/core/unite-legal.ts`.
- Détails :
  - Nettoyage à la volée de la mention "suppression du nom commercial"

closes #1228 