### PR TITLE
feat: new typo "L’Annuaire des Entreprises"

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-Merci de contribuer à Annuaire des Entreprises ! Effacez cette ligne ainsi que, pour chaque ligne ci-dessous, les cas ne correspondant pas à votre contribution :)
+Merci de contribuer à l’Annuaire des Entreprises ! Effacez cette ligne ainsi que, pour chaque ligne ci-dessous, les cas ne correspondant pas à votre contribution :)
 
 - Amélioration technique. | Correction d'un bug. | Changement mineur.
 - Zones impactées : `chemin/vers/le/fichier/contenant/les/variables/impactées`.

--- a/CONTRIBUTE-CONTENT.md
+++ b/CONTRIBUTE-CONTENT.md
@@ -1,6 +1,6 @@
 # Tutoriel : Comment contribuer aux pages de contenus ?
 
-Pour rappel, github agit comme une sorte de bibliothèque du code. Dans cette bibliothèque se trouve le [livre de l'Annuaire des Entreprises](https://github.com/annuaire-entreprises-data-gouv-fr/site)
+Pour rappel, github agit comme une sorte de bibliothèque du code. Dans cette bibliothèque se trouve le [livre de l’Annuaire des Entreprises](https://github.com/annuaire-entreprises-data-gouv-fr/site)
 
 Le contenu est centralisé de manière très pratique dans le dossier [/data](https://github.com/annuaire-entreprises-data-gouv-fr/site/tree/main/data)
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 <a href="https://annuaire-entreprises.data.gouv.fr/historique-des-modifications"><img src="https://img.shields.io/badge/Page-changelog-blue.svg" alt="Changelog Badge"></a>
 <a href="https://annuaire-entreprises.data.gouv.fr/a-propos/stats"><img src="https://img.shields.io/badge/Page-stats-blue.svg" alt="Statistiques Badge"></a>
 
-Dépôt du site [Annuaire des Entreprises](https://annuaire-entreprises.data.gouv.fr). Pour [l’API Recherche d’Entreprises](https://api.gouv.fr/les-api/api-recherche-entreprises), consultez le [dépôt de l’API](https://github.com/annuaire-entreprises-data-gouv-fr/search-api).
+Dépôt du site [L'Annuaire des Entreprises](https://annuaire-entreprises.data.gouv.fr). Pour [l’API Recherche d’Entreprises](https://api.gouv.fr/les-api/api-recherche-entreprises), consultez le [dépôt de l’API](https://github.com/annuaire-entreprises-data-gouv-fr/search-api).
 
 Ce site met à disposition des citoyens et des agents les données ouvertes (open-data) des entreprises, associations et administrations dotées d'un n° SIREN/SIRET.
 
@@ -32,10 +32,10 @@ Pour protéger un siren et en limiter la diffusion [suivez la procédure](https:
 
 ## Dépôts liés 🏗
 
-Voici la liste des dépôts de code du projet [Annuaire des Entreprises](https://annuaire-entreprises.data.gouv.fr) :
+Voici la liste des dépôts de code du projet [L'Annuaire des Entreprises](https://annuaire-entreprises.data.gouv.fr) :
 
-| Description                         | Accès                                                                       |
-| ----------------------------------- | --------------------------------------------------------------------------- |
+| Description                         | Accès                                                                             |
+| ----------------------------------- | --------------------------------------------------------------------------------- |
 | Le site Web                         | [par ici 👉](https://github.com/annuaire-entreprises-data-gouv-fr/site)           |
 | Les actions SEO                     | [par ici 👉](https://github.com/annuaire-entreprises-data-gouv-fr/seo)            |
 | L’API du Moteur de recherche        | [par ici 👉](https://github.com/annuaire-entreprises-data-gouv-fr/search-api)     |

--- a/app/(header-default)/a-propos/budget/page.tsx
+++ b/app/(header-default)/a-propos/budget/page.tsx
@@ -16,9 +16,8 @@ export default function Budget() {
       <TextWrapper>
         <h1>Budget</h1>
         <p>
-          L’
           <a href="https://annuaire-entreprises.data.gouv.fr">
-            <strong>Annuaire des Entreprises</strong>
+            <strong>L’Annuaire des Entreprises</strong>
           </a>{' '}
           est un service public numérique, c’est pourquoi nous sommes
           transparents sur les ressources allouées et la manière dont elles sont

--- a/app/(header-default)/a-propos/comment-ca-marche/page.tsx
+++ b/app/(header-default)/a-propos/comment-ca-marche/page.tsx
@@ -16,7 +16,7 @@ export default function About() {
   return (
     <>
       <TextWrapper>
-        <h1>À propos de L’Annuaire des Entreprises</h1>
+        <h1>À propos de l’Annuaire des Entreprises</h1>
         <p>
           Ce site permet de retrouver toutes les données publiques détenues par
           l’administration sur une entreprise, une association ou une

--- a/app/(header-default)/a-propos/donnees-extrait-kbis/page.tsx
+++ b/app/(header-default)/a-propos/donnees-extrait-kbis/page.tsx
@@ -72,8 +72,8 @@ export default function ExtraitKbis() {
               <INPI /> à votre système d’information.
             </li>
             <li>
-              Intégrer le lien vers la page Annuaire des Entreprises dans votre
-              application.
+              Intégrer le lien vers la page de l’Annuaire des Entreprises dans
+              votre application.
             </li>
           </ol>
           <p>

--- a/app/(header-default)/a-propos/equipe/page.tsx
+++ b/app/(header-default)/a-propos/equipe/page.tsx
@@ -54,7 +54,7 @@ const team = [
 ];
 
 export const metadata: Metadata = {
-  title: "Qui est l’équipe derrière l'Annuaire des Entreprises",
+  title: 'Qui est l’équipe derrière l’Annuaire des Entreprises',
   alternates: {
     canonical: 'https://annuaire-entreprises.data.gouv.fr/a-propos/equipe',
   },

--- a/app/(header-default)/definitions/page.tsx
+++ b/app/(header-default)/definitions/page.tsx
@@ -34,7 +34,7 @@ export default function AllDefinitionsPage() {
 }
 
 export const metadata: Metadata = {
-  title: "Definitions des termes utilisées sur l'Annuaire des Entreprises",
+  title: 'Definitions des termes utilisées sur l’Annuaire des Entreprises',
   alternates: {
     canonical: 'https://annuaire-entreprises.data.gouv.fr/definitions',
   },

--- a/app/(header-default)/faq/page.tsx
+++ b/app/(header-default)/faq/page.tsx
@@ -39,7 +39,7 @@ export default function FAQPage() {
 }
 
 export const metadata: Metadata = {
-  title: "FAQ de l'Annuaire des Entreprises",
+  title: 'FAQ de l’Annuaire des Entreprises',
   alternates: {
     canonical: 'https://annuaire-entreprises.data.gouv.fr/faq',
   },

--- a/app/(header-default)/formulaire/supprimer-donnees-personnelles-entreprise/page.tsx
+++ b/app/(header-default)/formulaire/supprimer-donnees-personnelles-entreprise/page.tsx
@@ -6,7 +6,7 @@ import HidePersonalDataPageClient from './_components';
 export const metadata: Metadata = {
   title: 'Demande de suppression de données personnelles',
   description:
-    "Demande de suppression de données personnelles de dirigeant d'entreprise sur l'Annuaire des Entreprises",
+    'Demande de suppression de données personnelles de dirigeant d’entreprise sur l’Annuaire des Entreprises',
   robots: 'index, follow',
 };
 

--- a/app/(header-default)/lp/agent-public/page.tsx
+++ b/app/(header-default)/lp/agent-public/page.tsx
@@ -6,7 +6,7 @@ import { AppRouterProps } from '#utils/server-side-helper/app/extract-params';
 import styles from './style.module.css';
 
 export const metadata: Metadata = {
-  title: 'Espace agent | Annuaire des Entreprises',
+  title: 'Espace agent | L’Annuaire des Entreprises',
   description:
     'Les informations des entreprises sont toutes dans l’espace agent !',
   robots: 'index, follow',

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -22,7 +22,7 @@ export default async function HomeLayout({
         <link
           rel="search"
           type="application/opensearchdescription+xml"
-          title="Annuaire des Entreprises"
+          title="L'Annuaire des Entreprises"
           href="https://annuaire-entreprises.data.gouv.fr/opensearch.xml"
         />
       </head>

--- a/components/feedback-modal/index.tsx
+++ b/components/feedback-modal/index.tsx
@@ -60,7 +60,7 @@ export default function FeedbackModal({ agentContactInfo }: IProps) {
           <FloatingHelpButton>
             <button
               ref={buttonRef}
-              aria-label="Dites-nous tout : partager une idée, un bug, une question ou une donnée manquante avec l'équipe de l'Annuaire des Entreprises"
+              aria-label="Dites-nous tout : partager une idée, un bug, une question ou une donnée manquante avec l'équipe de l’Annuaire des Entreprises"
               onClick={() => (opened ? handleClose() : handleOpen())}
               aria-controls="feedback-modal"
               aria-haspopup="dialog"
@@ -79,7 +79,7 @@ export default function FeedbackModal({ agentContactInfo }: IProps) {
           role="dialog"
           ref={dialogRef}
           className={styles.dialog}
-          aria-label="Partager une idée, un bug, une question ou une donnée manquante avec l'équipe de l'Annuaire des Entreprises"
+          aria-label="Partager une idée, un bug, une question ou une donnée manquante avec l'équipe de l’Annuaire des Entreprises"
         >
           <ButtonClose
             onClick={handleClose}

--- a/components/footer/index.tsx
+++ b/components/footer/index.tsx
@@ -173,7 +173,7 @@ const Footer = () => (
               </ul>
               <br />
               <strong className="fr-footer__top-cat">
-                Annuaire des Entreprises
+                L’Annuaire des Entreprises
               </strong>
               <ul className="fr-footer__top-list">
                 <li>

--- a/components/meta/index.tsx
+++ b/components/meta/index.tsx
@@ -1,5 +1,5 @@
 export const SITE_NAME =
-  'Annuaire des Entreprises : le moteur de recherche officiel';
+  'L’Annuaire des Entreprises : le moteur de recherche officiel';
 export const SITE_DESCRIPTION =
   'L’administration permet aux particuliers et agents publics de vérifier les informations juridiques officielles d’une entreprise : SIREN, SIRET, TVA Intracommunautaire, code APE/NAF, capital social, justificatif d’immatriculation, dirigeants, convention collective…';
 

--- a/data/definitions/annonce-legale.yml
+++ b/data/definitions/annonce-legale.yml
@@ -1,7 +1,7 @@
 title: Annonce légale
 
 seo:
-  title: Annonce légale - définition - Annuaire des Entreprises
+  title: Annonce légale - définition - L’Annuaire des Entreprises
   description: Une annonce légale est un texte, mentionnant les informations juridiques d’une entreprise, publié dans un journal d'annonces légales.
 body: |
 

--- a/data/definitions/association.yml
+++ b/data/definitions/association.yml
@@ -1,7 +1,7 @@
 title: Association
 
 seo:
-  title: Association - définition - Annuaire des Entreprises
+  title: Association - définition - L’Annuaire des Entreprises
   description: Une association est la “convention par laquelle deux ou plusieurs personnes mettent en commun, d’une façon permanente, leurs connaissances ou leur activité dans un but autre que de partager des bénéfices…”
 body: |
 

--- a/data/definitions/bodacc.yml
+++ b/data/definitions/bodacc.yml
@@ -2,7 +2,7 @@ administrations:
   - dila
 title: BODACC
 seo:
-  title: BODACC - définition - Annuaire des Entreprises
+  title: BODACC - définition - L’Annuaire des Entreprises
   description: Le Bulletin Officiel des Annonces Civiles et Commerciales (BODACC) publie les actes enregistrés au registre du commerce et des sociétés (RCS).
 body: |
 

--- a/data/definitions/certification-qualiopi.yml
+++ b/data/definitions/certification-qualiopi.yml
@@ -1,7 +1,7 @@
 title: Certification Qualiopi
 
 seo:
-  title: Certification Qualiopi - définition - Annuaire des Entreprises
+  title: Certification Qualiopi - définition - L’Annuaire des Entreprises
   description: Le label Qualiopi est une certification permettant d'attester de la qualité d'un organisme de formation. Cette certification est obligatoire pour obtenir des financements publics.
 
 ## 3. CTA BOUTON BLEU en fin de page

--- a/data/definitions/code-ape.yml
+++ b/data/definitions/code-ape.yml
@@ -1,7 +1,7 @@
 title: Code APE
 
 seo:
-  title: Code APE - définition - Annuaire des Entreprises
+  title: Code APE - définition - L’Annuaire des Entreprises
   description: Le code APE (Activité Principale Exercée) ou code NAF (Nomenclature d’Activité Française) permet d'identifier le secteur d'activité principale d’une entreprise.
 body: |
 

--- a/data/definitions/entrepreneur-de-spectacles-vivants.yml
+++ b/data/definitions/entrepreneur-de-spectacles-vivants.yml
@@ -1,6 +1,6 @@
 title: Entrepreneur de spectacles vivants
 seo:
-  title: Entrepreneur de spectacles vivants - définition - Annuaire des Entreprises
+  title: Entrepreneur de spectacles vivants - définition - L’Annuaire des Entreprises
   description: Un entrepreneur de spectacles vivants est une personne morale ou physique qui exerce une activité d'exploitation de lieux de spectacles, de production ou de diffusion de spectacles.
 more:
   - label: 'Économie Sociale et Solidaire (ESS)'
@@ -27,7 +27,7 @@ body: |
 
   Un récépissé de déclaration au statut valide est valable cinq ans.
 
-  Exemple de récépissé tel qu'il apparaît sur le site de l'Annuaire des Entreprises, on y trouve :
+  Exemple de récépissé tel qu'il apparaît sur le site de l’Annuaire des Entreprises, on y trouve :
 
   * Le numéro de récépissé (qui est le même que le numéro de déclaration).
   * Le statut de validité du récépissé

--- a/data/definitions/entreprise-individuelle.yml
+++ b/data/definitions/entreprise-individuelle.yml
@@ -1,7 +1,7 @@
 title: Entreprise individuelle
 
 seo:
-  title: Entreprise individuelle - définition - Annuaire des Entreprises
+  title: Entreprise individuelle - définition - L’Annuaire des Entreprises
   description: Une entreprise individuelle est une forme d'entreprise simplifiée qui regroupe les statuts d'entrepreneur individuel, de micro-entrepreneur et anciennement d'auto-entrepreneur.
 more:
   - label: 'Personne physique'
@@ -51,7 +51,7 @@ body: |
 
   Certaines activités - notamment agricoles - sont cependant interdites aux micro-entrepreneurs.
 
-  ## **La diffusion des données des entreprises individuelles sur l'Annuaire des Entreprises**
+  ## **La diffusion des données des entreprises individuelles sur l’Annuaire des Entreprises**
 
   Les informations légales des entrepreneurs individuels sont ouvertes et facilement accessibles, comme pour les autres formes d'entreprises.
 
@@ -59,4 +59,4 @@ body: |
 
   Les entrepreneurs et travailleurs indépendants qui le souhaitent peuvent donc **[rendre une partie de leurs informations légales non diffusibles](https://statut-diffusion-sirene.insee.fr/),** ou ****inversement les rendre diffusibles, directement auprès de l'INSEE.
 
-  Une fois la mise à jour du statut de diffusion effectuée auprès de l'INSEE, elle est effective sur l'Annuaire des Entreprises dans un délai d'un mois maximum.
+  Une fois la mise à jour du statut de diffusion effectuée auprès de l'INSEE, elle est effective sur l’Annuaire des Entreprises dans un délai d'un mois maximum.

--- a/data/definitions/entreprise-non-diffusible.yml
+++ b/data/definitions/entreprise-non-diffusible.yml
@@ -1,7 +1,7 @@
 title: Entreprise non-diffusible
 
 seo:
-  title: Entreprise non diffusible - définition - Annuaire des Entreprises
+  title: Entreprise non diffusible - définition - L’Annuaire des Entreprises
   description: Une entreprise non diffusible est une entreprise dont les informations légales ne sont pas diffusibles ni ouvertes au public.
 
 cta:
@@ -40,4 +40,4 @@ body: |
 
   Pour demander la non-diffusion (ou la diffusion) de vos informations légales, vous devez vous adresser aux services de l'INSEE : [https://statut-diffusion-sirene.insee.fr](https://statut-diffusion-sirene.insee.fr/)
 
-  Une fois la demande acceptée, votre statut de diffusion sera mis à jour dans un délai d'un mois maximum sur le site de l'Annuaire des Entreprises.
+  Une fois la demande acceptée, votre statut de diffusion sera mis à jour dans un délai d'un mois maximum sur le site de l’Annuaire des Entreprises.

--- a/data/definitions/etablissement.yml
+++ b/data/definitions/etablissement.yml
@@ -1,7 +1,7 @@
 title: Établissement
 
 seo:
-  title: Etablissement - définition - Annuaire des Entreprises
+  title: Etablissement - définition - L’Annuaire des Entreprises
   description: L'établissement est une dénomination juridique désignant l'unité de production d'une entreprise, liée à son unité légale.
 body: |
   ## **Établissement : définition**
@@ -44,7 +44,7 @@ body: |
   * SIRET : 345 130 488 00132
   * SIRET : 345 130 488 00611
 
-  ## **Identifier un établissement grâce à l'Annuaire des Entreprises**
+  ## **Identifier un établissement grâce à l’Annuaire des Entreprises**
 
   L'Annuaire des Entreprises référence les pages établissements de façon distincte de leur unité légale, tout en mentionnant l'unité légale de référence et l'arborescence entre les établissements, notamment s'il s'agit d'un établissement secondaire ou s'il s'agit de l'unité légale de référence.
 

--- a/data/definitions/index-egapro-egalite-professionnelle-entre-les-femmes-et-les-hommes.yml
+++ b/data/definitions/index-egapro-egalite-professionnelle-entre-les-femmes-et-les-hommes.yml
@@ -1,7 +1,7 @@
 title: Index Egapro (égalité professionnelle entre les femmes et les hommes)
 
 seo:
-  title: Index Egapro - définition - Annuaire des Entreprises
+  title: Index Egapro - définition - L’Annuaire des Entreprises
   description: L'index Egapro est un score calculé sur plusieurs indicateurs, permettant de mesurer le niveau d'égalité professionnelle entre les femmes et les hommes dans les entreprises de plus de 50 salariés.
   url: https://annuaire-entreprises.data.gouv.fr/defintion/egapro-egalite-professionnelle-femme-homme
 more:
@@ -64,7 +64,7 @@ body: |
 
   * En vous rendant sa fiche Annuaire des Entreprises, sur la page “Labels et certificats” d'une entreprise de plus de 50 salariés basée en France. Exemple avec l'entreprise EDF : <https://annuaire-entreprises.data.gouv.fr/labels-certificats/552081317>
   * En consultant le moteur de recherche du ministère du Travail : <https://egapro.travail.gouv.fr/index-egapro/recherche>
-  * En consultant directement la base de données Egapro disponible sur [datagouv.fr](http://datagouv.fr) et utilisée par l'Annuaire des Entreprises : <https://www.data.gouv.fr/fr/datasets/index-egalite-professionnelle-f-h-des-entreprises-de-50-salaries-ou-plus/>
+  * En consultant directement la base de données Egapro disponible sur [datagouv.fr](http://datagouv.fr) et utilisée par l’Annuaire des Entreprises : <https://www.data.gouv.fr/fr/datasets/index-egalite-professionnelle-f-h-des-entreprises-de-50-salaries-ou-plus/>
 
   Pour aller plus loin : comprendre la méthode de calcul des indicateurs <https://egapro.travail.gouv.fr/aide-simulation>
 

--- a/data/definitions/kbis.yml
+++ b/data/definitions/kbis.yml
@@ -1,7 +1,7 @@
 title: Kbis
 
 seo:
-  title: Kbis - définition - Annuaire des Entreprises
+  title: Kbis - définition - L’Annuaire des Entreprises
   description: Le Kbis (ou extrait Kbis) est un document qui prouve l’existence légale d’une entreprise et son immatriculation au registre du commerce et des sociétés (RCS).
 
 body: |

--- a/data/definitions/label-professionnel-du-bio.yml
+++ b/data/definitions/label-professionnel-du-bio.yml
@@ -5,7 +5,7 @@
 ## 1. METADONNEES SEO
 title: Label « professionnels du bio »
 seo:
-  title: Label « professionnels du bio » - définition - Annuaire des Entreprises
+  title: Label « professionnels du bio » - définition - L’Annuaire des Entreprises
   description: Le label « professionnels du bio » concerne les producteurs, distributeurs, revendeurs et importateurs agricoles et alimentaires qui sont certifiés bio.
 
 ## 3. CTA BOUTON BLEU en fin de page
@@ -35,7 +35,7 @@ body: |
 
   Pour être reconnu professionnel du Bio, il faut en faire la demande et être certifié par [les organismes certificateurs agréés par l’Institut National de l’Origine et de la qualité (INAO)](https://www.inao.gouv.fr/Espace-professionnel-et-outils/Controles-des-signes-d-identification-de-l-origine-et-de-la-qualite-SIQO/Les-organismes-de-controle).
 
-  L'[agence bio](https://www.agencebio.org) recense ensuite tous les professionnels du bio présents en France. La certification des professionnels du bio est également disponible dans les pages “labels et certificats” de l'Annuaire des Entreprises pour les entreprises concernées.
+  L'[agence bio](https://www.agencebio.org) recense ensuite tous les professionnels du bio présents en France. La certification des professionnels du bio est également disponible dans les pages “labels et certificats” de l’Annuaire des Entreprises pour les entreprises concernées.
 
   ## **Se faire accompagner pour être certifié bio**
 

--- a/data/definitions/numero-nic.yml
+++ b/data/definitions/numero-nic.yml
@@ -1,7 +1,7 @@
 title: Numéro NIC
 
 seo:
-  title: Numéro NIC - définition - Annuaire des Entreprises
+  title: Numéro NIC - définition - L’Annuaire des Entreprises
   description: Le Numéro Interne de Classement (NIC) permet d’identifier un établissement au sein de l’entreprise à laquelle il est rattachée.
 body: |
   ## **Le Numéro NIC : définition**

--- a/data/definitions/numero-siren.yml
+++ b/data/definitions/numero-siren.yml
@@ -1,7 +1,7 @@
 title: Numéro SIREN
 
 seo:
-  title: Numéro SIREN - définition - Annuaire des Entreprises
+  title: Numéro SIREN - définition - L’Annuaire des Entreprises
   description: Le SIREN est un numéro unique qui permet d’identifier chaque entreprise auprès des administrations
 body: |
 

--- a/data/definitions/numero-siret.yml
+++ b/data/definitions/numero-siret.yml
@@ -1,7 +1,7 @@
 title: Numéro SIRET
 
 seo:
-  title: Numéro SIRET - définition - Annuaire des Entreprises
+  title: Numéro SIRET - définition - L’Annuaire des Entreprises
   description: Le SIRET est un numéro unique qui permet d’identifier chaque établissement d’une entreprise auprès des administrations.
 
 body: |

--- a/data/definitions/personne-morale.yml
+++ b/data/definitions/personne-morale.yml
@@ -1,6 +1,6 @@
 title: Personne morale
 seo:
-  title: Personne morale - définition - Annuaire des Entreprises
+  title: Personne morale - définition - L’Annuaire des Entreprises
   description: Une personne morale est une entité juridique souvent composée de plusieurs personnes physiques alliées pour réaliser une activité commune.
 more:
   - label: 'Personne physique'

--- a/data/definitions/personne-physique.yml
+++ b/data/definitions/personne-physique.yml
@@ -1,7 +1,7 @@
 title: Personne physique
 
 seo:
-  title: Personne physique - définition - Annuaire des Entreprises
+  title: Personne physique - définition - L’Annuaire des Entreprises
   description: Une personne physique est un être humain, ayant une identité civile, doté de la personnalité juridique. Ce cadre permet à l’entrepreneur de créer une entreprise non distincte de sa personne physique.
 
 body: |

--- a/data/definitions/societe-a-mission.yml
+++ b/data/definitions/societe-a-mission.yml
@@ -1,7 +1,7 @@
 title: Société à mission
 
 seo:
-  title: Société à mission - définition - Annuaire des Entreprises
+  title: Société à mission - définition - L’Annuaire des Entreprises
   description: Une société à mission est une entreprise qui fixe un pour plusieurs objectifs sociaux, sociétaux et environnementaux dans son activité.
 body: |
 

--- a/data/definitions/tva-intracommunautaire.yml
+++ b/data/definitions/tva-intracommunautaire.yml
@@ -1,6 +1,6 @@
 label: définition
 seo:
-  title: Numéro de TVA intracommunautaire - définition - Annuaire des Entreprises
+  title: Numéro de TVA intracommunautaire - définition - L’Annuaire des Entreprises
   description: Le numéro de TVA intracommunautaire est un identifiant unique assigné par l’administration fiscale à toute entreprise assujettie à la TVA.
 administrations:
   - vies
@@ -66,7 +66,7 @@ body: |
 
   ## Une entreprise peut-elle avoir plusieurs numéros de TVA intracommunautaire ?
 
-  Une entreprise assujettie à la TVA possède un numéro de TVA pour chacun de ses codes d’activité (NAF/APE). Dans ce cas, le numéro de TVA affiché sur Annuaire des Entreprises est celui de son premier code d’activité.
+  Une entreprise assujettie à la TVA possède un numéro de TVA pour chacun de ses codes d’activité (NAF/APE). Dans ce cas, le numéro de TVA affiché sur l’Annuaire des Entreprises est celui de son premier code d’activité.
 more:
   - label: Consulter la page dédiée sur service-public.fr
     href: https://entreprendre.service-public.fr/vosdroits/F23570

--- a/data/faq/association-introuvable.yml
+++ b/data/faq/association-introuvable.yml
@@ -19,9 +19,9 @@ faqTargets:
   - association
 title: Pourquoi je ne retrouve pas une association dans les résultats de recherche ?
 seo:
-  description: Seules les associations qui possèdent un numéro SIREN et un numéro SIRET ont une fiche dans l'Annuaire des Entreprises.
+  description: Seules les associations qui possèdent un numéro SIREN et un numéro SIRET ont une fiche dans l’Annuaire des Entreprises.
 body: |
-  Seules les associations qui possèdent un numéro SIREN et un numéro SIRET ont une fiche dans l'Annuaire des Entreprises.
+  Seules les associations qui possèdent un numéro SIREN et un numéro SIRET ont une fiche dans l’Annuaire des Entreprises.
 
   Celles qui n'en disposent pas ne sont donc référencées.
 

--- a/data/faq/donnees-financieres.yml
+++ b/data/faq/donnees-financieres.yml
@@ -16,7 +16,7 @@ body: |
 
   Sous certaines conditions, les micro, petites et moyennes entreprises peuvent demander à ce que leurs données ne soient pas publiées et restent confidentielles.  
 
-  ## Quelles sont les données financières affichées par l'Annuaire des Entreprises ?
+  ## Quelles sont les données financières affichées par l’Annuaire des Entreprises ?
 
   Nous affichons les informations les plus importantes permettant de renseigner sur la santé financière d'une société : date de clôture des comptes, chiffre d'affaires, marge brut, EBE, résultat net.
 

--- a/data/faq/extrait-kbis.yml
+++ b/data/faq/extrait-kbis.yml
@@ -32,7 +32,7 @@ body: |
 
   ## Vous êtes agent(e) public ? 
 
-  Dans ce cas, un extrait INPI ou extrait RNE vous suffit. Vous pouvez le télécharger gratuitement sur l'Annuaire des Entreprises. 
+  Dans ce cas, un extrait INPI ou extrait RNE vous suffit. Vous pouvez le télécharger gratuitement sur l’Annuaire des Entreprises. 
 
   ## Vous êtes dirigeant(e) d’une société commerciale ?
 

--- a/data/faq/supprimer-donnees-personnelles-entreprise.yml
+++ b/data/faq/supprimer-donnees-personnelles-entreprise.yml
@@ -26,7 +26,7 @@ body: |
 
   Ces données sont publiques mais vous pouvez vous opposer à ce qu’un site internet les publie.
 
-  Ainsi, pour faire disparaitre vos informations de dirigeant(e) du site Annuaire des Entreprises vous pouvez nous en faire la demande.
+  Ainsi, pour faire disparaitre vos informations de dirigeant(e) du site L'Annuaire des Entreprises vous pouvez nous en faire la demande.
 
 more:
   - label: Changer de statut de diffusion (entreprise individuelle)

--- a/data/landing-pages/collectivites-territoriales.yml
+++ b/data/landing-pages/collectivites-territoriales.yml
@@ -45,7 +45,7 @@ reassurance:
       - Etablissements scolaires associés pour les communes
   - title: Comment ça marche ?
     body: |
-      Les collectivités territoriales (communes, départements, régions) - quelle que soit leur taille - possèdent toutes un numéro SIRET et par conséquent une fiche sur l'[Annuaire des Entreprises](https://annuaire-entreprises.data.gouv.fr).
+      Les collectivités territoriales (communes, départements, régions) - quelle que soit leur taille - possèdent toutes un numéro SIRET et par conséquent une fiche sur [l’Annuaire des Entreprises](https://annuaire-entreprises.data.gouv.fr).
 datasources:
   - insee
   - mi

--- a/data/landing-pages/entrepreneur-spectacles-vivants.yml
+++ b/data/landing-pages/entrepreneur-spectacles-vivants.yml
@@ -42,7 +42,7 @@ reassurance:
       - Avis de situation
   - title: Comment ça marche ?
     body: |
-      Tous les entrepreneurs du spectacle vivant - quelle que soit leur forme juridique - possèdent un numéro SIRET et par conséquent une fiche sur l'[Annuaire des Entreprises](https://annuaire-entreprises.data.gouv.fr).
+      Tous les entrepreneurs du spectacle vivant - quelle que soit leur forme juridique - possèdent un numéro SIRET et par conséquent une fiche sur [l’Annuaire des Entreprises](https://annuaire-entreprises.data.gouv.fr).
 datasources:
   - insee
   - mc

--- a/data/landing-pages/entreprises-individuelles.yml
+++ b/data/landing-pages/entreprises-individuelles.yml
@@ -39,9 +39,9 @@ reassurance:
       - Code NAF / APE
       - Avis de situation
       - Extrait d’Immatriculation au RNE
-  - title: "Entrepreneurs : pourquoi utiliser l'Annuaire dans vos démarches ?"
+  - title: 'Entrepreneurs : pourquoi utiliser l’Annuaire dans vos démarches ?'
     body: |
-      L'[Annuaire des Entreprises](https://annuaire-entreprises.data.gouv.fr) centralise les informations qui sont le plus souvent demandées lors des démarches administratives des entrepreneurs et des indépendants.
+      [L'Annuaire des Entreprises](https://annuaire-entreprises.data.gouv.fr) centralise les informations qui sont le plus souvent demandées lors des démarches administratives des entrepreneurs et des indépendants.
 datasources:
   - insee
   - inpi
@@ -61,7 +61,7 @@ body: |
 
   ## Pourquoi je ne retrouve pas mon entreprise individuelle dans le moteur de recherche ?
 
-  Rendre les informations d’une entreprise individuelle non diffusibles a pour conséquence de **rendre l’entreprise introuvable sur le moteur de recherche de l'Annuaire des Entreprises**.
+  Rendre les informations d’une entreprise individuelle non diffusibles a pour conséquence de **rendre l’entreprise introuvable sur le moteur de recherche de l’Annuaire des Entreprises**.
 
 
   Plus d’informations [sur notre FAQ](https://annuaire-entreprises.data.gouv.fr/faq#independant).

--- a/data/landing-pages/ess-economie-sociale-solidaire.yml
+++ b/data/landing-pages/ess-economie-sociale-solidaire.yml
@@ -26,7 +26,7 @@ filter:
   value: ess
 seo:
   title: Consultez le moteur de recherche de l’ESS
-  description: Retrouvez rapidement les associations et entreprises de l'Économie Sociale et Solidaire (ESS) en France, grâce au moteur de recherche de l'Annuaire des Entreprises.
+  description: Retrouvez rapidement les associations et entreprises de l'Économie Sociale et Solidaire (ESS) en France, grâce au moteur de recherche de l’Annuaire des Entreprises.
 reassurance:
   - title: Définition de l’Économie Sociale et Solidaire
     body: |
@@ -40,7 +40,7 @@ reassurance:
       - SIREN / SIRET
   - title: Comment ça marche ?
     body: |
-      Toutes les structures de l'ESS - quelle que soit leur forme juridique - possèdent un numéro SIRET et par conséquent une fiche sur l'[Annuaire des Entreprises](https://annuaire-entreprises.data.gouv.fr).
+      Toutes les structures de l'ESS - quelle que soit leur forme juridique - possèdent un numéro SIRET et par conséquent une fiche sur [l’Annuaire des Entreprises](https://annuaire-entreprises.data.gouv.fr).
 datasources:
   - insee
 body: |

--- a/data/landing-pages/organisme-formation-qualiopi.yml
+++ b/data/landing-pages/organisme-formation-qualiopi.yml
@@ -8,7 +8,7 @@ filter:
   value: qualiopi
 seo:
   title: Moteur de recherche des organismes de formation certifiés Qualiopi
-  description: Retrouvez rapidement les organismes de formation certifiés Qualiopi, grâce au moteur de recherche de l'Annuaire des Entreprises.
+  description: Retrouvez rapidement les organismes de formation certifiés Qualiopi, grâce au moteur de recherche de l’Annuaire des Entreprises.
 reassurance:
   - title: Que signifie la certification Qualiopi ?
     body: |
@@ -24,7 +24,7 @@ reassurance:
       - Adresse
       - SIREN / SIRET
   - title: Comment ça marche ?
-    body: Tous les organismes certifiés Qualiopi - quelle que soit leur forme juridique - possèdent un numéro SIRET et par conséquent une fiche sur [Annuaire des Entreprises](https://annuaire-entreprises.data.gouv.fr)
+    body: Tous les organismes certifiés Qualiopi - quelle que soit leur forme juridique - possèdent un numéro SIRET et par conséquent une fiche sur [l’Annuaire des Entreprises](https://annuaire-entreprises.data.gouv.fr)
 datasources:
   - insee
   - mtpei

--- a/pages/administration/index.tsx
+++ b/pages/administration/index.tsx
@@ -12,7 +12,7 @@ const StatusPage: NextPageWithLayout<{
 }> = ({ allAdministrations }) => (
   <>
     <Meta
-      title="Liste des administrations partenaires de l'Annuaire des Entreprises"
+      title="Liste des administrations partenaires de l’Annuaire des Entreprises"
       canonical="https://annuaire-entreprises.data.gouv.fr/administration"
     />
     <TextWrapper>

--- a/pages/connexion/agent-public.tsx
+++ b/pages/connexion/agent-public.tsx
@@ -9,7 +9,7 @@ const Login = () => {
   return (
     <>
       <Meta
-        title="Accédez à votre espace agent public sur Annuaire des Entreprises"
+        title="Accédez à votre espace agent public sur l’Annuaire des Entreprises"
         noIndex={true}
       />
       <h1>Espace agent public</h1>

--- a/pages/donnees/api.tsx
+++ b/pages/donnees/api.tsx
@@ -25,7 +25,7 @@ const StatusPage: NextPageWithLayout<IProps> = ({
 }) => (
   <>
     <Meta
-      title="Statut des API utilisées par l'Annuaire des Entreprises"
+      title="Statut des API utilisées par l’Annuaire des Entreprises"
       noIndex
     />
     <div

--- a/pages/donnees/sources.tsx
+++ b/pages/donnees/sources.tsx
@@ -24,7 +24,7 @@ const DataSourcesPage: NextPageWithLayout<IProps> = ({
 }) => (
   <>
     <Meta
-      title="Sources des données utilisées dans l'Annuaire des Entreprises"
+      title="Sources des données utilisées dans l’Annuaire des Entreprises"
       canonical="https://annuaire-entreprises.data.gouv.fr/donnees/sources"
     />
     <div className="content-container">

--- a/pages/partager/index.tsx
+++ b/pages/partager/index.tsx
@@ -13,8 +13,7 @@ const Partager: NextPageWithLayout = () => {
       <TextWrapper>
         <h1>Réutiliser & partager</h1>
         <p>
-          L’
-          <a href="/comment-ca-marche">Annuaire des Entreprises</a> permet de
+          <a href="/comment-ca-marche">L’Annuaire des Entreprises</a> permet de
           facilement retrouver l’ensemble des informations publiques disponibles
           sur une entreprise, une association ou une administration.
           <br />
@@ -169,7 +168,7 @@ const Partager: NextPageWithLayout = () => {
             <code>
               {`
 <a href="https://annuaire-entreprises.data.gouv.fr/">
-  Retrouvez votre numéro sur siren sur l'Annuaire des
+  Retrouvez votre numéro sur siren sur l’Annuaire des
   Entreprises
 </a>
             `}

--- a/public/opensearch.xml
+++ b/public/opensearch.xml
@@ -1,9 +1,10 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
-  <ShortName>Annuaire des Entreprises</ShortName>
+  <ShortName>L’Annuaire des Entreprises</ShortName>
   <Description>Rechercher une entreprise, une adssociation ou une administration publique</Description>
   <Image>/favicons/favicon.svg</Image>
   <Language>fr</Language>
   <InputEncoding>UTF-8</InputEncoding>
-  <Url type="text/html" template="https://annuaire-entreprises.data.gouv.fr/rechercher?terme={searchTerms}"/>
+  <Url type="text/html"
+    template="https://annuaire-entreprises.data.gouv.fr/rechercher?terme={searchTerms}" />
 </OpenSearchDescription>

--- a/utils/helpers/formatting/unite-legale-label.ts
+++ b/utils/helpers/formatting/unite-legale-label.ts
@@ -73,7 +73,7 @@ export const uniteLegalePageTitle = (uniteLegale: IUniteLegale) => {
     uniteLegale.nomComplet
   }${city} - SIREN ${formatIntFr(
     uniteLegale.siren
-  )} | Annuaire des Entreprises`;
+  )} | L’Annuaire des Entreprises`;
 };
 
 export const uniteLegalePageDescription = (uniteLegale: IUniteLegale) =>
@@ -106,5 +106,5 @@ export const etablissementPageTitle = (
     uniteLegale.nomComplet
   }${city} - SIRET ${formatSiret(
     etablissement.siret
-  )} | Annuaire des Entreprises`;
+  )} | L’Annuaire des Entreprises`;
 };


### PR DESCRIPTION
- Changement mineur
- Zones impactées : Tous les fichiers qui contiennent le nom du site
- Détails :
Si le nom est utilisé dans une phrase, le L est minuscule, exemple : Bienvenue sur l'Annuaire des Enterprises
Si les nom est utilisé seul ou est cité, le L est majuscule, exemple : Voici le code source du site "L'Annuaire des Entreprises"
Aussi, l'apostrophe ’ est privilégié sur ' pour éviter les conflits de guillemets

#1237 
