### PR TITLE
fix: good redirect after agent public login

### DIFF
--- a/app/(header-default)/lp/agent-public/page.tsx
+++ b/app/(header-default)/lp/agent-public/page.tsx
@@ -1,3 +1,5 @@
+import { IronSession } from 'iron-session';
+import { Metadata } from 'next';
 import { default as ButtonProConnect } from '#components-ui/button-pro-connect';
 import Container from '#components-ui/container';
 import { administrationsMetaData } from '#models/administrations';
@@ -5,8 +7,6 @@ import { isLoggedIn } from '#models/user/rights';
 import { ISession } from '#models/user/session';
 import { AppRouterProps } from '#utils/server-side-helper/app/extract-params';
 import getSession from '#utils/server-side-helper/app/get-session';
-import { IronSession } from 'iron-session';
-import { Metadata } from 'next';
 import styles from './style.module.css';
 
 export const metadata: Metadata = {
@@ -51,11 +51,7 @@ const LandingPageAgent = async (props: AppRouterProps) => {
           {isLoggedIn(session) ? (
             isLoggedInMessage(session)
           ) : (
-            <ButtonProConnect
-              useCurrentPathForRediction={false}
-              alternatePathForRedirection={pathFrom as string}
-              event="BTN_LP_HERO"
-            />
+            <ButtonProConnect shouldRedirectToReferer event="BTN_LP_HERO" />
           )}
         </div>
         <img src="/images/lp-agent/secure-folder 1.svg" alt="" />
@@ -127,11 +123,7 @@ const LandingPageAgent = async (props: AppRouterProps) => {
           {isLoggedIn(session) ? (
             isLoggedInMessage(session)
           ) : (
-            <ButtonProConnect
-              useCurrentPathForRediction={false}
-              alternatePathForRedirection={pathFrom as string}
-              event="BTN_LP_BOTTOM"
-            />
+            <ButtonProConnect shouldRedirectToReferer event="BTN_LP_BOTTOM" />
           )}
         </section>
       </Container>

--- a/components-ui/button-pro-connect/index.tsx
+++ b/components-ui/button-pro-connect/index.tsx
@@ -1,29 +1,32 @@
 'use client';
 
 import { usePathname } from 'next/navigation';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { logConversionEvent } from '#utils/matomo';
 
 type IProps = {
-  useCurrentPathForRediction: boolean;
-  alternatePathForRedirection?: string;
+  shouldRedirectToReferer?: boolean;
   event: string;
 };
 
 const ButtonProConnect: React.FC<IProps> = ({
-  alternatePathForRedirection,
-  useCurrentPathForRediction,
+  shouldRedirectToReferer = false,
   event = 'BTN_DEFAULT',
 }) => {
-  let pathFrom = null;
+  const [referrer, setReferrer] = useState<string | null>(null);
   const currentPath = usePathname();
 
-  if (useCurrentPathForRediction) {
-    pathFrom = currentPath;
-  }
-  if (alternatePathForRedirection) {
-    pathFrom = alternatePathForRedirection;
-  }
+  useEffect(() => {
+    setReferrer(document.referrer);
+  }, []);
+
+  const isFromSite =
+    referrer?.indexOf(
+      process.env.NEXT_PUBLIC_BASE_URL || 'https://annuaire-entreprises'
+    ) === 0;
+
+  const pathFrom =
+    shouldRedirectToReferer && isFromSite ? referrer : currentPath;
 
   return (
     <form action="/api/auth/agent-connect/login" method="get">

--- a/components/espace-agent-components/agent-wall/index.tsx
+++ b/components/espace-agent-components/agent-wall/index.tsx
@@ -55,7 +55,7 @@ const AgentWall: React.FC<{
               </>
             )}
           </p>
-          <ButtonProConnect useCurrentPathForRediction event="AGENT_WALL" />
+          <ButtonProConnect event="AGENT_WALL" />
         </FloatingModal>
         <div className={style['blur']} tab-index="-1" aria-hidden>
           <p>

--- a/components/header/header-app-router.tsx
+++ b/components/header/header-app-router.tsx
@@ -1,5 +1,4 @@
 import getSession from '#utils/server-side-helper/app/get-session';
-import usePathServer from 'hooks/use-path-server';
 import { HeaderCore } from './header-core';
 
 type IProps = {
@@ -20,7 +19,6 @@ export const HeaderAppRouter: React.FC<IProps> = async ({
   currentSearchTerm = '',
 }) => {
   const session = await getSession();
-  const pathFrom = usePathServer();
 
   return (
     <HeaderCore
@@ -30,7 +28,6 @@ export const HeaderAppRouter: React.FC<IProps> = async ({
       useAgentCTA={useAgentCTA}
       plugin={plugin}
       session={session}
-      pathFrom={pathFrom}
       currentSearchTerm={currentSearchTerm}
     />
   );

--- a/components/header/header-core/index.tsx
+++ b/components/header/header-core/index.tsx
@@ -1,9 +1,9 @@
-import dynamic from 'next/dynamic';
-import React from 'react';
 import { PrintNever } from '#components-ui/print-visibility';
 import LoadBar from '#components/load-bar';
 import SearchBar from '#components/search-bar';
 import { ISession } from '#models/user/session';
+import dynamic from 'next/dynamic';
+import React from 'react';
 import Menu from '../menu';
 import styles from './styles.module.css';
 
@@ -23,7 +23,6 @@ type IProps = {
   useInfoBanner?: boolean;
   session: ISession | null;
   plugin?: JSX.Element;
-  pathFrom: string;
 };
 
 export const HeaderCore: React.FC<IProps> = ({
@@ -34,7 +33,6 @@ export const HeaderCore: React.FC<IProps> = ({
   useMap = false,
   plugin = null,
   session,
-  pathFrom,
 }) => {
   return (
     <>
@@ -98,11 +96,7 @@ export const HeaderCore: React.FC<IProps> = ({
                       ) : null}
                       <div className={styles.menuMobile}>
                         <ChangelogNotificationWithoutSSR />
-                        <Menu
-                          session={session}
-                          useAgentCTA={useAgentCTA}
-                          pathFrom={pathFrom}
-                        />
+                        <Menu session={session} useAgentCTA={useAgentCTA} />
                       </div>
                     </div>
                     {useSearchBar ? (
@@ -118,11 +112,7 @@ export const HeaderCore: React.FC<IProps> = ({
                           <ChangelogNotificationWithoutSSR />
                         </li>
                         <li>
-                          <Menu
-                            session={session}
-                            useAgentCTA={useAgentCTA}
-                            pathFrom={pathFrom}
-                          />
+                          <Menu session={session} useAgentCTA={useAgentCTA} />
                         </li>
                       </ul>
                     </div>

--- a/components/header/header-page-router.tsx
+++ b/components/header/header-page-router.tsx
@@ -1,4 +1,3 @@
-import { usePathname } from 'next/navigation';
 import useSession from 'hooks/use-session';
 import { HeaderCore } from './header-core';
 
@@ -19,7 +18,6 @@ export const HeaderPageRouter: React.FC<IProps> = ({
   currentSearchTerm = '',
 }) => {
   const session = useSession();
-  const pathFrom = usePathname();
 
   return (
     <HeaderCore
@@ -29,7 +27,6 @@ export const HeaderPageRouter: React.FC<IProps> = ({
       useAgentCTA={useAgentCTA}
       plugin={plugin}
       session={session}
-      pathFrom={pathFrom || ''}
       currentSearchTerm={currentSearchTerm}
     />
   );

--- a/components/header/menu/espace-agent-link.tsx
+++ b/components/header/menu/espace-agent-link.tsx
@@ -4,9 +4,9 @@ import { Icon } from '#components-ui/icon/wrapper';
 import { logConversionEvent } from '#utils/matomo';
 import styles from './styles.module.css';
 
-export const EspaceAgentLink = ({ pathFrom }: { pathFrom: string }) => (
+export const EspaceAgentLink = () => (
   <a
-    href={`/lp/agent-public?pathFrom=${encodeURIComponent(pathFrom)}`}
+    href={'/lp/agent-public'}
     className="fr-link"
     title="Se connecter à l'espace agent"
     onClick={() => logConversionEvent('HEADER_LOGIN')}

--- a/components/header/menu/index.tsx
+++ b/components/header/menu/index.tsx
@@ -9,9 +9,8 @@ import styles from './styles.module.css';
 
 const Menu: React.FC<{
   session: ISession | null;
-  pathFrom: string;
   useAgentCTA: boolean;
-}> = ({ session, pathFrom, useAgentCTA }) => {
+}> = ({ session, useAgentCTA }) => {
   return isLoggedIn(session) ? (
     <div className={styles.menuLogout + ' fr-link'} tabIndex={0}>
       <div>
@@ -40,16 +39,14 @@ const Menu: React.FC<{
       >
         <a
           aria-label="Se déconnecter de l'espace agent public"
-          href={`/api/auth/agent-connect/logout?pathFrom=${encodeURIComponent(
-            pathFrom
-          )}`}
+          href={'/api/auth/agent-connect/logout'}
         >
           <div>Se déconnecter</div>
         </a>
       </FloatingModal>
     </div>
   ) : useAgentCTA ? (
-    <EspaceAgentLink pathFrom={pathFrom} />
+    <EspaceAgentLink />
   ) : null;
 };
 

--- a/hooks/use-path-server.ts
+++ b/hooks/use-path-server.ts
@@ -1,7 +1,0 @@
-import { headers } from 'next/headers';
-
-export default function usePathServer(): string {
-  const headersList = headers();
-  // read the custom x-url header
-  return headersList.get('x-pathname') || '';
-}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,6 +1,3 @@
-import { getIronSession } from 'iron-session';
-import type { NextRequest } from 'next/server';
-import { NextResponse } from 'next/server';
 import { Exception } from '#models/exceptions';
 import { ISession } from '#models/user/session';
 import {
@@ -10,6 +7,9 @@ import {
 } from '#utils/helpers';
 import logErrorInSentry from '#utils/sentry';
 import { sessionOptions, setVisitTimestamp } from '#utils/session';
+import { getIronSession } from 'iron-session';
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
 
 const shouldRedirect = (path: string, search: string, url: string) => {
   try {
@@ -60,8 +60,6 @@ const shouldRedirect = (path: string, search: string, url: string) => {
 
 // This function can be marked `async` if using `await` inside
 export async function middleware(request: NextRequest) {
-  const pathname = request.nextUrl.pathname;
-
   const redirection = shouldRedirect(
     request.nextUrl.pathname,
     request.nextUrl.search,
@@ -73,17 +71,9 @@ export async function middleware(request: NextRequest) {
   }
 
   /**
-   * pathname for /app router RSC
-   */
-
-  // https://github.com/vercel/next.js/issues/43704#issuecomment-1411186664
-  // Store current request url in a custom header, which you can read later
-  const requestHeaders = new Headers(request.headers);
-  requestHeaders.set('x-pathname', pathname);
-
-  /**
    * siren redirection logging
    */
+  const requestHeaders = new Headers(request.headers);
   const nextUrl = request.nextUrl;
   const paramIsPresent = nextUrl.search.indexOf('redirected=1') > -1;
 

--- a/pages/api/auth/agent-connect/login.ts
+++ b/pages/api/auth/agent-connect/login.ts
@@ -6,7 +6,9 @@ import { AgentConnectionFailedException } from './callback';
 
 export default withSession(async function loginRoute(req, res) {
   try {
-    await setPathFrom(req.session, (req?.query?.pathFrom || '') as string);
+    const pathFrom =
+      (req?.query?.pathFrom as string) || req.headers.referer || '';
+    await setPathFrom(req.session, pathFrom);
     const url = await agentConnectAuthorizeUrl(req);
     res.redirect(url);
   } catch (e: any) {

--- a/pages/api/auth/agent-connect/logout.ts
+++ b/pages/api/auth/agent-connect/logout.ts
@@ -6,7 +6,7 @@ import withSession from '#utils/session/with-session';
 
 export default withSession(async function logoutRoute(req, res) {
   try {
-    await setPathFrom(req.session, (req?.query?.pathFrom || '') as string);
+    await setPathFrom(req.session, req.headers.referer || '');
     const url = await agentConnectLogoutUrl(req);
     res.redirect(url);
   } catch (e: any) {


### PR DESCRIPTION
- Correctif
- Zones impactées : `./middleware.ts`.
- Détails :
  - The usePathServer hook has been removed.
  - login : The middleware is now responsible for adding the pathFrom param when navigating to the "espace agent" page
  - logout : referer is directly used from the route to determine the pathFrom param


#1220 