### PR TITLE
chore: update link, remove linkedin link and fix typo

### DIFF
--- a/app/(header-default)/justificatif-immatriculation-pdf/[slug]/page.tsx
+++ b/app/(header-default)/justificatif-immatriculation-pdf/[slug]/page.tsx
@@ -47,7 +47,7 @@ const InpiPDF = (props: AppRouterProps) => {
             Un téléchargement normal prend{' '}
             <strong>entre 10 et 20 secondes</strong>. <br />
             Mais quand le service est surchargé, le téléchargement peut
-            atteindre plusieurs minutes <strong>voire même échouer</strong>.
+            atteindre plusieurs minutes <strong>voire échouer</strong>.
           </Info>
           <p>
             Le téléchargement de l’extrait d’immatriculation au Répertoire

--- a/components/feedback-modal/feedback-form.tsx
+++ b/components/feedback-modal/feedback-form.tsx
@@ -86,14 +86,6 @@ export default function FeedbackForm({ onSubmit, agentContactInfo }: IProps) {
             rel="noopener noreferrer"
           >
             Tchap
-          </a>{' '}
-          et sur{' '}
-          <a
-            href="https://www.linkedin.com/company/annuaire-des-entreprises"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            LinkedIn
           </a>
           .
         </p>

--- a/components/footer/index.tsx
+++ b/components/footer/index.tsx
@@ -122,9 +122,9 @@ const Footer = () => (
                     className="fr-footer__top-link"
                     target="_blank"
                     rel="noreferrer noopener"
-                    href="https://mon-entreprise.fr"
+                    href="https://mon-entreprise.urssaf.fr/"
                   >
-                    mon-entreprise.fr
+                    mon-entreprise.urssaf.fr
                   </a>
                 </li>
                 <li className="fr-footer__content-item">


### PR DESCRIPTION
- Changement mineur.
- Zones impactées : `multiple files`.
- Détails :
  - Suppression lien Linkedin
  - voire même -> voire
  - mon-entreprise -> mon-entreprise.urssaf

Closes #1251 

<img width="482" alt="image" src="https://github.com/user-attachments/assets/c371fc33-1b15-405f-a186-b0c0038483ed">

<img width="276" alt="image" src="https://github.com/user-attachments/assets/2d6bf9a3-2c4e-404c-9f41-943ada9350b3">

