### PR TITLE
fix: remove warnings

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,45 +6,6 @@
         "allow": ["warn", "error"]
       }
     ],
-    "import/order": [
-      "warn",
-      {
-        "pathGroupsExcludedImportTypes": ["builtin"],
-        "pathGroups": [
-          {
-            "group": "internal",
-            "pattern": "#clients/**"
-          },
-          {
-            "group": "internal",
-            "pattern": "#components/**"
-          },
-          {
-            "group": "internal",
-            "pattern": "#components-ui/**"
-          },
-          {
-            "group": "internal",
-            "pattern": "#models/**"
-          },
-          {
-            "group": "internal",
-            "pattern": "#public/*"
-          },
-          {
-            "group": "internal",
-            "pattern": "#utils/*"
-          }
-        ],
-        "newlines-between": "never",
-        "groups": [
-          "builtin",
-          "external",
-          "internal",
-          ["parent", "sibling", "index"]
-        ]
-      }
-    ],
     "@next/next/no-css-tags": "off",
     "@next/next/no-head-element": "off",
     "@next/next/no-html-link-for-pages": "off",

--- a/app/(header-default)/carte/[slug]/page.tsx
+++ b/app/(header-default)/carte/[slug]/page.tsx
@@ -8,7 +8,6 @@ import { getEtablissementWithLatLongFromSlug } from '#models/core/etablissement'
 import extractParamsAppRouter, {
   AppRouterProps,
 } from '#utils/server-side-helper/app/extract-params';
-import getSession from '#utils/server-side-helper/app/get-session';
 
 export const generateMetadata = async (
   props: AppRouterProps
@@ -26,7 +25,6 @@ export const generateMetadata = async (
 
 const EtablissementMapPage = async (props: AppRouterProps) => {
   const { slug } = extractParamsAppRouter(props);
-  const session = await getSession();
   const etablissement = await getEtablissementWithLatLongFromSlug(slug);
 
   return (

--- a/app/(header-default)/dirigeants/[slug]/_component/sections/entreprise/dirigeant-content.tsx
+++ b/app/(header-default)/dirigeants/[slug]/_component/sections/entreprise/dirigeant-content.tsx
@@ -39,7 +39,7 @@ export function DirigeantContent({
         const defaultDenom = dirigeant.denomination || dirigeant.siren;
         //@ts-ignore
         infos.push([
-          <a href={`/dirigeants/${dirigeant.siren}`}>
+          <a key={dirigeant.siren} href={`/dirigeants/${dirigeant.siren}`}>
             → voir les dirigeants de {defaultDenom}
           </a>,
         ]);

--- a/app/(header-default)/lp/agent-public/page.tsx
+++ b/app/(header-default)/lp/agent-public/page.tsx
@@ -1,4 +1,3 @@
-import { IronSession } from 'iron-session';
 import { Metadata } from 'next';
 import { default as ButtonProConnect } from '#components-ui/button-pro-connect';
 import Container from '#components-ui/container';
@@ -19,14 +18,13 @@ export const metadata: Metadata = {
   },
 };
 
-const isLoggedInMessage = (session: IronSession<ISession> | null) => (
+const isLoggedInMessage = (session: ISession | null) => (
   <div>
     Vous êtes connecté en tant que : <strong>{session?.user?.email}</strong>
   </div>
 );
 
 const LandingPageAgent = async (props: AppRouterProps) => {
-  const { pathFrom } = props.searchParams;
   const session = await getSession();
 
   return (

--- a/utils/server-side-helper/app/get-session.ts
+++ b/utils/server-side-helper/app/get-session.ts
@@ -1,8 +1,9 @@
-import { getIronSession, IronSession } from 'iron-session';
-import { cookies } from 'next/headers';
 import { ISession } from '#models/user/session';
 import { sessionOptions } from '#utils/session';
+import { getIronSession } from 'iron-session';
+import { cookies } from 'next/headers';
 
-export default async function getSession(): Promise<IronSession<ISession> | null> {
-  return await getIronSession<ISession>(cookies(), sessionOptions);
+export default async function getSession(): Promise<ISession | null> {
+  const ironSession = await getIronSession<ISession>(cookies(), sessionOptions);
+  return { ...ironSession };
 }


### PR DESCRIPTION
- Amélioration technique
- Zones impactées : `multiples`.
- Détails :
  - Suppression d'un warning en dev mode côté serveur : la session était une classe (IronSession) et puisque les méthodes ne pouvent pas être communiquées de serveur à client, il y avait constamment une erreur. Solution proposée : transformer la classe en objet.
  - Suppression d'un warning en dev mode côté client : "key" nécessaire dans un tableau
  - Suppression de la règle ESLint sur les imports : Prettier réorganisait les imports en contradiction avec la règle ESLint

Sur (quasiment toutes les pages) :
<img width="672" alt="image" src="https://github.com/user-attachments/assets/0563d3f6-56be-4030-9b6d-d35e45e86b0e">


Sur cette page :
http://localhost:3000/dirigeants/552032534

<img width="434" alt="image" src="https://github.com/user-attachments/assets/2bc90392-4925-4f6c-9c3a-fda7102f14b4">
