### PR TITLE
fix: la poste pdf incorrectly cast as 404

### DIFF
--- a/hooks/fetch/download-pdf.ts
+++ b/hooks/fetch/download-pdf.ts
@@ -15,7 +15,7 @@ export function usePDFDownloader(pdfLink: string) {
           return await httpGet<Blob>(pdfLink, { responseType: 'blob' });
         } catch (e: any) {
           if (isPdfNotFound(e?.message)) {
-            throw new HttpNotFound('Not heyhey found - 404');
+            throw new HttpNotFound('Not found - 404');
           }
           throw e;
         }

--- a/hooks/fetch/download-pdf.ts
+++ b/hooks/fetch/download-pdf.ts
@@ -5,7 +5,7 @@ import { httpGet } from '#utils/network';
 import logErrorInSentry from '#utils/sentry';
 import { useFetchExternalData } from './use-fetch-data';
 
-const is404 = (msg: string) => msg.indexOf('Siren non existant') !== 0;
+const isPdfNotFound = (msg: string) => msg.indexOf('Siren non existant') === 0;
 
 export function usePDFDownloader(pdfLink: string) {
   return useFetchExternalData(
@@ -14,8 +14,8 @@ export function usePDFDownloader(pdfLink: string) {
         try {
           return await httpGet<Blob>(pdfLink, { responseType: 'blob' });
         } catch (e: any) {
-          if (is404(e?.message)) {
-            throw new HttpNotFound('Not found - 404');
+          if (isPdfNotFound(e?.message)) {
+            throw new HttpNotFound('Not heyhey found - 404');
           }
           throw e;
         }


### PR DESCRIPTION
- Correction d'un bug
- Zones impactées : `https://annuaire-entreprises.data.gouv.fr/justificatif-immatriculation-pdf/***`.
- Détails :
  - le siren de la poste affiche "introuvable" au lieu d'"echec"
