### PR TITLE
Refacto routes roles handles

### DIFF
--- a/app/(header-default)/annonces/[slug]/_components/observations-rne.tsx
+++ b/app/(header-default)/annonces/[slug]/_components/observations-rne.tsx
@@ -7,6 +7,7 @@ import { FullTable } from '#components/table/full';
 import { EAdministration } from '#models/administrations/EAdministration';
 import { IUniteLegale } from '#models/core/types';
 import { ISession } from '#models/user/session';
+import { APIRoutesPaths } from 'app/api/data-fetching/routes-paths';
 import { useAPIRouteData } from 'hooks/fetch/use-API-route-data';
 
 export const ObservationsRNE: React.FC<{
@@ -14,7 +15,7 @@ export const ObservationsRNE: React.FC<{
   session: ISession | null;
 }> = ({ uniteLegale, session }) => {
   const observations = useAPIRouteData(
-    'observations',
+    APIRoutesPaths.Observations,
     uniteLegale.siren,
     session
   );

--- a/app/(header-default)/dirigeants/[slug]/_component/sections/association/dirigeants.tsx
+++ b/app/(header-default)/dirigeants/[slug]/_component/sections/association/dirigeants.tsx
@@ -13,6 +13,7 @@ import { isDataSuccess, isUnauthorized } from '#models/data-fetching';
 import { ISession } from '#models/user/session';
 import { formatSiret } from '#utils/helpers';
 import { extractAssociationEtablissements } from '#utils/helpers/association';
+import { APIRoutesPaths } from 'app/api/data-fetching/routes-paths';
 import { useAPIRouteData } from 'hooks/fetch/use-API-route-data';
 import { useMemo, useState } from 'react';
 
@@ -31,7 +32,7 @@ const NoDirigeants = () => (
 function DirigeantsAssociationSection({ uniteLegale, session }: IProps) {
   const [selectedSiret, setSelectedSiret] = useState<string[]>([]);
   const associationProtected = useAPIRouteData(
-    'espace-agent/association-protected',
+    APIRoutesPaths.EspaceAgentAssociationProtected,
     uniteLegale.siren,
     session
   );

--- a/app/(header-default)/dirigeants/[slug]/_component/sections/entreprise/beneficiaires/agent-section.tsx
+++ b/app/(header-default)/dirigeants/[slug]/_component/sections/entreprise/beneficiaires/agent-section.tsx
@@ -11,6 +11,7 @@ import { IBeneficairesEffectif } from '#models/espace-agent/beneficiaires';
 import { UseCase } from '#models/user/agent';
 import { ISession } from '#models/user/session';
 import { formatDatePartial } from '#utils/helpers';
+import { APIRoutesPaths } from 'app/api/data-fetching/routes-paths';
 import { useAPIRouteData } from 'hooks/fetch/use-API-route-data';
 import { useMemo } from 'react';
 
@@ -31,7 +32,7 @@ const ProtectedBeneficiairesSection: React.FC<{
     [useCase]
   );
   const beneficiaires = useAPIRouteData(
-    'espace-agent/beneficiaires',
+    APIRoutesPaths.EspaceAgentBeneficiaires,
     uniteLegale.siren,
     session,
     params

--- a/app/(header-default)/dirigeants/[slug]/_component/sections/entreprise/index.tsx
+++ b/app/(header-default)/dirigeants/[slug]/_component/sections/entreprise/index.tsx
@@ -12,6 +12,7 @@ import {
 } from '#models/data-fetching';
 import { IDirigeants } from '#models/rne/types';
 import { ISession } from '#models/user/session';
+import { APIRoutesPaths } from 'app/api/data-fetching/routes-paths';
 import { useAPIRouteData } from 'hooks/fetch/use-API-route-data';
 import BeneficiairesSection from './beneficiaires';
 import RCSRNEComparison from './rcs-rne-comparison';
@@ -48,13 +49,13 @@ export function DirigeantInformation({
   session: ISession | null;
 }) {
   const dirigeantsRNE = useAPIRouteData(
-    'rne-dirigeants',
+    APIRoutesPaths.RneDirigeants,
     uniteLegale.siren,
     session
   );
 
   const mandatairesRCS = useAPIRouteData(
-    'espace-agent/rcs-mandataires',
+    APIRoutesPaths.EspaceAgentRcsMandataires,
     uniteLegale.siren,
     session
   );

--- a/app/(header-default)/documents/[slug]/_components/actes/associations.tsx
+++ b/app/(header-default)/documents/[slug]/_components/actes/associations.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useMemo, useState } from 'react';
 import ButtonLink from '#components-ui/button';
 import FAQLink from '#components-ui/faq-link';
 import { DataSectionClient } from '#components/section/data-section';
@@ -12,7 +11,9 @@ import { isDataSuccess } from '#models/data-fetching';
 import { ISession } from '#models/user/session';
 import { formatDate, formatSiret } from '#utils/helpers';
 import { extractAssociationEtablissements } from '#utils/helpers/association';
+import { APIRoutesPaths } from 'app/api/data-fetching/routes-paths';
 import { useAPIRouteData } from 'hooks/fetch/use-API-route-data';
+import { useMemo, useState } from 'react';
 
 const NoDocument = () => (
   <>Aucun document n’a été retrouvé pour cette association.</>
@@ -25,7 +26,7 @@ export const AgentActesAssociation: React.FC<{
   const [selectedSiret, setSelectedSiret] = useState<string[]>([]);
 
   const associationProtected = useAPIRouteData(
-    'espace-agent/association-protected',
+    APIRoutesPaths.EspaceAgentAssociationProtected,
     uniteLegale.siren,
     session
   );

--- a/app/(header-default)/documents/[slug]/_components/actes/rne.tsx
+++ b/app/(header-default)/documents/[slug]/_components/actes/rne.tsx
@@ -11,6 +11,7 @@ import { IUniteLegale, isServicePublic } from '#models/core/types';
 import { IActesRNE } from '#models/rne/types';
 import { ISession } from '#models/user/session';
 import { formatDateLong } from '#utils/helpers';
+import { APIRoutesPaths } from 'app/api/data-fetching/routes-paths';
 import { useAPIRouteData } from 'hooks/fetch/use-API-route-data';
 
 export const AgentActesRNE: React.FC<{
@@ -18,7 +19,7 @@ export const AgentActesRNE: React.FC<{
   session: ISession | null;
 }> = ({ uniteLegale, session }) => {
   const documentsRne = useAPIRouteData(
-    'espace-agent/rne/documents',
+    APIRoutesPaths.EspaceAgentRneDocuments,
     uniteLegale.siren,
     session
   );

--- a/app/(header-default)/documents/[slug]/_components/carte-professionnelle-TP-section.tsx
+++ b/app/(header-default)/documents/[slug]/_components/carte-professionnelle-TP-section.tsx
@@ -6,6 +6,7 @@ import { AsyncDataSectionClient } from '#components/section/data-section/client'
 import { EAdministration } from '#models/administrations/EAdministration';
 import { IUniteLegale } from '#models/core/types';
 import { ISession } from '#models/user/session';
+import { APIRoutesPaths } from 'app/api/data-fetching/routes-paths';
 import { useAPIRouteData } from 'hooks/fetch/use-API-route-data';
 
 export default function CarteProfessionnelleTPSection({
@@ -16,7 +17,7 @@ export default function CarteProfessionnelleTPSection({
   session: ISession | null;
 }) {
   const carteProfessionnelleTravauxPublics = useAPIRouteData(
-    'espace-agent/carte-professionnelle-TP',
+    APIRoutesPaths.EspaceAgentCarteProfessionnelleTP,
     uniteLegale.siege.siret,
     session
   );

--- a/app/(header-default)/donnees-financieres/[slug]/_components/bilans.tsx
+++ b/app/(header-default)/donnees-financieres/[slug]/_components/bilans.tsx
@@ -16,6 +16,7 @@ import {
 import { ISession } from '#models/user/session';
 import { formatDateLong } from '#utils/helpers';
 import { getFiscalYear } from '#utils/helpers/formatting/format-fiscal-year';
+import { APIRoutesPaths } from 'app/api/data-fetching/routes-paths';
 import { useAPIRouteData } from 'hooks/fetch/use-API-route-data';
 
 const NoBilans = () => (
@@ -27,7 +28,7 @@ const AgentBilansSection: React.FC<{
   session: ISession | null;
 }> = ({ uniteLegale, session }) => {
   const documents = useAPIRouteData(
-    'espace-agent/rne/documents',
+    APIRoutesPaths.EspaceAgentRneDocuments,
     uniteLegale.siren,
     session
   );

--- a/app/api/data-fetching/[...slug]/route.ts
+++ b/app/api/data-fetching/[...slug]/route.ts
@@ -1,6 +1,6 @@
 import { hasRights } from '#models/user/rights';
 import { ISession } from '#models/user/session';
-import { APIPath, APIRoutesHandlers } from '../routes-handlers';
+import { APIRoutesHandlers } from '../routes-handlers';
 import { APIRoutesScopes } from '../routes-scopes';
 import {
   APIRouteError,
@@ -19,8 +19,8 @@ async function getRoute(
   if (!(route in APIRoutesHandlers)) {
     throw new APIRouteError('API route not found', { route, slug }, 404);
   }
-  const handler = APIRoutesHandlers[route as APIPath];
-  const scope = APIRoutesScopes[route as APIPath];
+  const handler = APIRoutesHandlers[route];
+  const scope = APIRoutesScopes[route];
   if (!hasRights(session, scope)) {
     throw new APIRouteError(
       'User does not have the required scope for this API route',

--- a/app/api/data-fetching/get-beneficiaires-controller.ts
+++ b/app/api/data-fetching/get-beneficiaires-controller.ts
@@ -1,5 +1,6 @@
 import { getBeneficiaires } from '#models/espace-agent/beneficiaires';
 import { UseCase } from '#models/user/agent';
+import { APIRoutesPaths } from './routes-paths';
 import { APIRouteError } from './utils';
 
 export default function getBeneficiairesController(
@@ -9,11 +10,9 @@ export default function getBeneficiairesController(
   if (!('useCase' in params) || params.useCase in UseCase) {
     throw new APIRouteError(
       'Invalid useCase',
-      { slug: params.useCase, route: beneficiaireRoute },
+      { slug: params.useCase, route: APIRoutesPaths.EspaceAgentBeneficiaires },
       400
     );
   }
   return getBeneficiaires(slug, params.useCase);
 }
-
-export const beneficiaireRoute = 'espace-agent/beneficiaires';

--- a/app/api/data-fetching/routes-handlers.ts
+++ b/app/api/data-fetching/routes-handlers.ts
@@ -12,35 +12,26 @@ import { getDirigeantsRNE } from '#models/rne/dirigeants';
 import { getRNEObservations } from '#models/rne/observations';
 import { getSubventionsAssociationFromSlug } from '#models/subventions/association';
 import { buildAndVerifyTVA } from '#models/tva/verify';
-import { UnwrapPromise } from 'types';
 import getBeneficiairesController, {
   beneficiaireRoute,
 } from './get-beneficiaires-controller';
+import { APIRoutesPaths } from './routes-paths';
 
 export const APIRoutesHandlers = {
-  'espace-agent/carte-professionnelle-TP': getCarteProfessionnelleTravauxPublic,
-  'espace-agent/conformite': getConformiteEntreprise,
-  'espace-agent/opqibi': getOpqibi,
-  'espace-agent/qualibat': getQualibat,
-  'espace-agent/qualifelec': getQualifelec,
-  'espace-agent/rcs-mandataires': getMandatairesRCS,
+  [APIRoutesPaths.EspaceAgentCarteProfessionnelleTP]:
+    getCarteProfessionnelleTravauxPublic,
+  [APIRoutesPaths.EspaceAgentConformite]: getConformiteEntreprise,
+  [APIRoutesPaths.EspaceAgentOpqibi]: getOpqibi,
+  [APIRoutesPaths.EspaceAgentQualibat]: getQualibat,
+  [APIRoutesPaths.EspaceAgentQualifelec]: getQualifelec,
+  [APIRoutesPaths.EspaceAgentRcsMandataires]: getMandatairesRCS,
   [beneficiaireRoute]: getBeneficiairesController,
-  'espace-agent/rne/documents': getDocumentsRNEProtected,
-  'espace-agent/association-protected': getAssociationProtected,
-  'rne-dirigeants': getDirigeantsRNE,
-  observations: getRNEObservations,
-  association: getAssociationFromSlug,
-  'verify-tva': buildAndVerifyTVA,
-  'eori-validation': getEORIValidation,
-  'subventions-association': getSubventionsAssociationFromSlug,
-} as const;
-
-export type APIPath = keyof typeof APIRoutesHandlers;
-
-export type RouteResponse<T> = T extends APIPath
-  ? UnwrapPromise<ReturnType<(typeof APIRoutesHandlers)[T]>>
-  : never;
-
-export type RouteParams<T> = T extends APIPath
-  ? Parameters<(typeof APIRoutesHandlers)[T]>[1]
-  : never;
+  [APIRoutesPaths.EspaceAgentRneDocuments]: getDocumentsRNEProtected,
+  [APIRoutesPaths.EspaceAgentAssociationProtected]: getAssociationProtected,
+  [APIRoutesPaths.RneDirigeants]: getDirigeantsRNE,
+  [APIRoutesPaths.Observations]: getRNEObservations,
+  [APIRoutesPaths.Association]: getAssociationFromSlug,
+  [APIRoutesPaths.VerifyTva]: buildAndVerifyTVA,
+  [APIRoutesPaths.EoriValidation]: getEORIValidation,
+  [APIRoutesPaths.SubventionsAssociation]: getSubventionsAssociationFromSlug,
+};

--- a/app/api/data-fetching/routes-handlers.ts
+++ b/app/api/data-fetching/routes-handlers.ts
@@ -12,9 +12,7 @@ import { getDirigeantsRNE } from '#models/rne/dirigeants';
 import { getRNEObservations } from '#models/rne/observations';
 import { getSubventionsAssociationFromSlug } from '#models/subventions/association';
 import { buildAndVerifyTVA } from '#models/tva/verify';
-import getBeneficiairesController, {
-  beneficiaireRoute,
-} from './get-beneficiaires-controller';
+import getBeneficiairesController from './get-beneficiaires-controller';
 import { APIRoutesPaths } from './routes-paths';
 
 export const APIRoutesHandlers = {
@@ -25,7 +23,7 @@ export const APIRoutesHandlers = {
   [APIRoutesPaths.EspaceAgentQualibat]: getQualibat,
   [APIRoutesPaths.EspaceAgentQualifelec]: getQualifelec,
   [APIRoutesPaths.EspaceAgentRcsMandataires]: getMandatairesRCS,
-  [beneficiaireRoute]: getBeneficiairesController,
+  [APIRoutesPaths.EspaceAgentBeneficiaires]: getBeneficiairesController,
   [APIRoutesPaths.EspaceAgentRneDocuments]: getDocumentsRNEProtected,
   [APIRoutesPaths.EspaceAgentAssociationProtected]: getAssociationProtected,
   [APIRoutesPaths.RneDirigeants]: getDirigeantsRNE,

--- a/app/api/data-fetching/routes-paths.ts
+++ b/app/api/data-fetching/routes-paths.ts
@@ -1,0 +1,17 @@
+export enum APIRoutesPaths {
+  EspaceAgentCarteProfessionnelleTP = 'espace-agent/carte-professionnelle-TP',
+  EspaceAgentConformite = 'espace-agent/conformite',
+  EspaceAgentOpqibi = 'espace-agent/opqibi',
+  EspaceAgentQualibat = 'espace-agent/qualibat',
+  EspaceAgentQualifelec = 'espace-agent/qualifelec',
+  EspaceAgentRcsMandataires = 'espace-agent/rcs-mandataires',
+  EspaceAgentBeneficiaires = 'espace-agent/beneficiaires',
+  EspaceAgentRneDocuments = 'espace-agent/rne/documents',
+  EspaceAgentAssociationProtected = 'espace-agent/association-protected',
+  RneDirigeants = 'rne-dirigeants',
+  Observations = 'observations',
+  Association = 'association',
+  VerifyTva = 'verify-tva',
+  EoriValidation = 'eori-validation',
+  SubventionsAssociation = 'subventions-association',
+}

--- a/app/api/data-fetching/routes-scopes.ts
+++ b/app/api/data-fetching/routes-scopes.ts
@@ -1,21 +1,22 @@
 import { AppScope } from '#models/user/rights';
-import { APIPath } from './routes-handlers';
+import { APIRoutesPaths } from './routes-paths';
 
-export const APIRoutesScopes: Record<APIPath, AppScope> = {
-  'espace-agent/carte-professionnelle-TP':
+export const APIRoutesScopes: Record<APIRoutesPaths, AppScope> = {
+  [APIRoutesPaths.EspaceAgentCarteProfessionnelleTP]:
     AppScope.carteProfessionnelleTravauxPublics,
-  'espace-agent/conformite': AppScope.conformite,
-  'espace-agent/opqibi': AppScope.protectedCertificats,
-  'espace-agent/qualibat': AppScope.protectedCertificats,
-  'espace-agent/qualifelec': AppScope.protectedCertificats,
-  'espace-agent/rcs-mandataires': AppScope.mandatairesRCS,
-  'espace-agent/beneficiaires': AppScope.beneficiaires,
-  'espace-agent/rne/documents': AppScope.documentsRne,
-  'espace-agent/association-protected': AppScope.associationProtected,
-  'rne-dirigeants': AppScope.opendata,
-  observations: AppScope.opendata,
-  association: AppScope.opendata,
-  'verify-tva': AppScope.opendata,
-  'eori-validation': AppScope.opendata,
-  'subventions-association': AppScope.subventionsAssociation,
+  [APIRoutesPaths.EspaceAgentConformite]: AppScope.conformite,
+  [APIRoutesPaths.EspaceAgentOpqibi]: AppScope.protectedCertificats,
+  [APIRoutesPaths.EspaceAgentQualibat]: AppScope.protectedCertificats,
+  [APIRoutesPaths.EspaceAgentQualifelec]: AppScope.protectedCertificats,
+  [APIRoutesPaths.EspaceAgentRcsMandataires]: AppScope.mandatairesRCS,
+  [APIRoutesPaths.EspaceAgentBeneficiaires]: AppScope.beneficiaires,
+  [APIRoutesPaths.EspaceAgentRneDocuments]: AppScope.documentsRne,
+  [APIRoutesPaths.EspaceAgentAssociationProtected]:
+    AppScope.associationProtected,
+  [APIRoutesPaths.RneDirigeants]: AppScope.opendata,
+  [APIRoutesPaths.Observations]: AppScope.opendata,
+  [APIRoutesPaths.Association]: AppScope.opendata,
+  [APIRoutesPaths.VerifyTva]: AppScope.opendata,
+  [APIRoutesPaths.EoriValidation]: AppScope.opendata,
+  [APIRoutesPaths.SubventionsAssociation]: AppScope.subventionsAssociation,
 };

--- a/app/api/data-fetching/utils.ts
+++ b/app/api/data-fetching/utils.ts
@@ -3,6 +3,7 @@ import { ISession } from '#models/user/session';
 import logErrorInSentry, { logInfoInSentry } from '#utils/sentry';
 import { userAgent } from 'next/server';
 import getSession from '../../../utils/server-side-helper/app/get-session';
+import { APIRoutesPaths } from './routes-paths';
 
 type RouteHandler = (
   request: Request,
@@ -82,7 +83,7 @@ export class APIRouteError extends Exception {
 export function getRouteAndSlug(context: { params: { slug: Array<string> } }) {
   try {
     const slug = context.params.slug.at(-1) as string;
-    const route = context.params.slug.slice(0, -1).join('/');
+    const route = context.params.slug.slice(0, -1).join('/') as APIRoutesPaths;
     return { route, slug };
   } catch (e) {
     throw new APIRouteError('Invalid route', { route: '', slug: '' }, 404, e);

--- a/components/association-section/index.tsx
+++ b/components/association-section/index.tsx
@@ -11,6 +11,7 @@ import { getPersonnalDataAssociation } from '#models/core/diffusion';
 import { IAssociation, IUniteLegale } from '#models/core/types';
 import { ISession } from '#models/user/session';
 import { IdRna, formatDate, formatIntFr } from '#utils/helpers';
+import { APIRoutesPaths } from 'app/api/data-fetching/routes-paths';
 import { useAPIRouteData } from 'hooks/fetch/use-API-route-data';
 import { AssociationNotFound } from './association-not-found';
 
@@ -144,7 +145,7 @@ const AssociationSection = ({
   const { idAssociation = '' } = uniteLegale.association;
 
   const association = useAPIRouteData(
-    'association',
+    APIRoutesPaths.Association,
     uniteLegale.siren,
     session
   );

--- a/components/badges-section/labels-and-certificates/protected-certificats.tsx
+++ b/components/badges-section/labels-and-certificates/protected-certificats.tsx
@@ -7,6 +7,7 @@ import { isAPINotResponding } from '#models/api-not-responding';
 import constants from '#models/constants';
 import { hasAnyError, isDataLoading } from '#models/data-fetching';
 import { ISession } from '#models/user/session';
+import { APIRoutesPaths } from 'app/api/data-fetching/routes-paths';
 import { useAPIRouteData } from 'hooks/fetch/use-API-route-data';
 import {
   LabelsAndCertificatesBadgesSection,
@@ -21,17 +22,17 @@ export const ProtectedCertificatesBadgesSection: React.FC<{
 }> = ({ uniteLegale, session }) => {
   const hasOtherCertificates = checkHasLabelsAndCertificates(uniteLegale);
   const opqibi = useAPIRouteData(
-    'espace-agent/opqibi',
+    APIRoutesPaths.EspaceAgentOpqibi,
     uniteLegale.siren,
     session
   );
   const qualibat = useAPIRouteData(
-    'espace-agent/qualibat',
+    APIRoutesPaths.EspaceAgentQualibat,
     uniteLegale.siege.siret,
     session
   );
   const qualifelec = useAPIRouteData(
-    'espace-agent/qualifelec',
+    APIRoutesPaths.EspaceAgentQualifelec,
     uniteLegale.siege.siret,
     session
   );

--- a/components/eori-cell/index.tsx
+++ b/components/eori-cell/index.tsx
@@ -11,6 +11,7 @@ import {
 } from '#models/data-fetching';
 import { ISession } from '#models/user/session';
 import { Siret, formatSiret } from '#utils/helpers';
+import { APIRoutesPaths } from 'app/api/data-fetching/routes-paths';
 import { useAPIRouteData } from 'hooks/fetch/use-API-route-data';
 
 type IProps = {
@@ -18,7 +19,11 @@ type IProps = {
   session: ISession | null;
 };
 export default function EORICell({ siret, session }: IProps) {
-  const eoriValidation = useAPIRouteData('eori-validation', siret, session);
+  const eoriValidation = useAPIRouteData(
+    APIRoutesPaths.EoriValidation,
+    siret,
+    session
+  );
 
   if (isDataLoading(eoriValidation)) {
     return (

--- a/components/espace-agent-components/certifications/opqibi-section.tsx
+++ b/components/espace-agent-components/certifications/opqibi-section.tsx
@@ -8,6 +8,7 @@ import { IUniteLegale } from '#models/core/types';
 import { IOpqibi } from '#models/espace-agent/certificats/opqibi';
 import { ISession } from '#models/user/session';
 import { formatDateLong } from '#utils/helpers';
+import { APIRoutesPaths } from 'app/api/data-fetching/routes-paths';
 import { useAPIRouteData } from 'hooks/fetch/use-API-route-data';
 
 export const OpqibiSection: React.FC<{
@@ -15,7 +16,7 @@ export const OpqibiSection: React.FC<{
   session: ISession | null;
 }> = ({ uniteLegale, session }) => {
   const opqibi = useAPIRouteData(
-    'espace-agent/opqibi',
+    APIRoutesPaths.EspaceAgentOpqibi,
     uniteLegale.siren,
     session
   );

--- a/components/espace-agent-components/certifications/qualibat-section.tsx
+++ b/components/espace-agent-components/certifications/qualibat-section.tsx
@@ -7,6 +7,7 @@ import { EAdministration } from '#models/administrations/EAdministration';
 import { IUniteLegale } from '#models/core/types';
 import { ISession } from '#models/user/session';
 import { formatDateLong } from '#utils/helpers';
+import { APIRoutesPaths } from 'app/api/data-fetching/routes-paths';
 import { useAPIRouteData } from 'hooks/fetch/use-API-route-data';
 
 export const QualibatSection: React.FC<{
@@ -14,7 +15,7 @@ export const QualibatSection: React.FC<{
   session: ISession | null;
 }> = ({ uniteLegale, session }) => {
   const qualibat = useAPIRouteData(
-    'espace-agent/qualibat',
+    APIRoutesPaths.EspaceAgentQualibat,
     uniteLegale.siege.siret,
     session
   );

--- a/components/espace-agent-components/certifications/qualifelec-section.tsx
+++ b/components/espace-agent-components/certifications/qualifelec-section.tsx
@@ -7,6 +7,7 @@ import { EAdministration } from '#models/administrations/EAdministration';
 import { IUniteLegale } from '#models/core/types';
 import { ISession } from '#models/user/session';
 import { formatDate, formatDateLong } from '#utils/helpers';
+import { APIRoutesPaths } from 'app/api/data-fetching/routes-paths';
 import { useAPIRouteData } from 'hooks/fetch/use-API-route-data';
 
 export function QualifelecSection({
@@ -17,7 +18,7 @@ export function QualifelecSection({
   session: ISession | null;
 }) {
   const qualifelec = useAPIRouteData(
-    'espace-agent/qualifelec',
+    APIRoutesPaths.EspaceAgentQualifelec,
     uniteLegale.siege.siret,
     session
   );

--- a/components/espace-agent-components/conformite-section.tsx
+++ b/components/espace-agent-components/conformite-section.tsx
@@ -6,6 +6,7 @@ import { TwoColumnTable } from '#components/table/simple';
 import { EAdministration } from '#models/administrations/EAdministration';
 import { IUniteLegale } from '#models/core/types';
 import { ISession } from '#models/user/session';
+import { APIRoutesPaths } from 'app/api/data-fetching/routes-paths';
 import { useAPIRouteData } from 'hooks/fetch/use-API-route-data';
 import Conformite from './conformite';
 
@@ -15,7 +16,7 @@ interface IProps {
 }
 function ConformiteSection({ uniteLegale, session }: IProps) {
   const conformite = useAPIRouteData(
-    'espace-agent/conformite',
+    APIRoutesPaths.EspaceAgentConformite,
     uniteLegale.siege.siret,
     session
   );

--- a/components/finances-section/association/index.tsx
+++ b/components/finances-section/association/index.tsx
@@ -9,6 +9,7 @@ import constants from '#models/constants';
 import { IAssociation } from '#models/core/types';
 import { ISession } from '#models/user/session';
 import { formatCurrency } from '#utils/helpers';
+import { APIRoutesPaths } from 'app/api/data-fetching/routes-paths';
 import { useAPIRouteData } from 'hooks/fetch/use-API-route-data';
 
 const ColorCircle = ({ color }: { color: string }) => (
@@ -28,7 +29,11 @@ export const FinancesAssociationSection: React.FC<{
   uniteLegale: IAssociation;
   session: ISession | null;
 }> = ({ uniteLegale, session }) => {
-  const data = useAPIRouteData('association', uniteLegale.siren, session);
+  const data = useAPIRouteData(
+    APIRoutesPaths.Association,
+    uniteLegale.siren,
+    session
+  );
   if (!data) return null;
 
   return (

--- a/components/subventions-association-section/index.tsx
+++ b/components/subventions-association-section/index.tsx
@@ -12,6 +12,7 @@ import { isUnauthorized } from '#models/data-fetching';
 import { ISubventions } from '#models/subventions/association';
 import { ISession } from '#models/user/session';
 import { formatCurrency } from '#utils/helpers';
+import { APIRoutesPaths } from 'app/api/data-fetching/routes-paths';
 import { useAPIRouteData } from 'hooks/fetch/use-API-route-data';
 import { useMemo } from 'react';
 
@@ -71,7 +72,7 @@ export const SubventionsAssociationSection: React.FC<{
   session: ISession | null;
 }> = ({ uniteLegale, session }) => {
   const subventions = useAPIRouteData(
-    'subventions-association',
+    APIRoutesPaths.SubventionsAssociation,
     uniteLegale.siren,
     session
   );

--- a/components/tva-cell/index.tsx
+++ b/components/tva-cell/index.tsx
@@ -10,6 +10,7 @@ import { IUniteLegale } from '#models/core/types';
 import { hasAnyError, isDataLoading } from '#models/data-fetching';
 import { ITVAIntracommunautaire } from '#models/tva';
 import { Siren, formatIntFr } from '#utils/helpers';
+import { APIRoutesPaths } from 'app/api/data-fetching/routes-paths';
 import { useAPIRouteData } from 'hooks/fetch/use-API-route-data';
 
 const NoTVA = () => (
@@ -82,7 +83,7 @@ const VerifyTVA: React.FC<{
   siren: Siren;
 }> = ({ tva, siren }) => {
   const { tvaNumber, mayHaveMultipleTVANumber } = tva;
-  const verification = useAPIRouteData('verify-tva', siren, null);
+  const verification = useAPIRouteData(APIRoutesPaths.VerifyTva, siren, null);
   if (isDataLoading(verification)) {
     return (
       <>

--- a/hooks/fetch/use-API-route-data.ts
+++ b/hooks/fetch/use-API-route-data.ts
@@ -1,4 +1,3 @@
-import { useEffect, useState } from 'react';
 import { IDataFetchingState } from '#models/data-fetching';
 import { InternalError } from '#models/exceptions';
 import { hasRights } from '#models/user/rights';
@@ -9,26 +8,33 @@ import {
   RequestAbortedDuringUnloadException,
 } from '#utils/network/frontend';
 import logErrorInSentry, { logWarningInSentry } from '#utils/sentry';
-import {
-  APIPath,
-  RouteParams,
-  RouteResponse,
-} from 'app/api/data-fetching/routes-handlers';
+import { APIRoutesHandlers } from 'app/api/data-fetching/routes-handlers';
+import { APIRoutesPaths } from 'app/api/data-fetching/routes-paths';
 import { APIRoutesScopes } from 'app/api/data-fetching/routes-scopes';
+import { useEffect, useState } from 'react';
+import { UnwrapPromise } from 'types';
 
-type Options<T extends APIPath> = {
+export type RouteResponse<T> = T extends APIRoutesPaths
+  ? UnwrapPromise<ReturnType<(typeof APIRoutesHandlers)[T]>>
+  : never;
+
+export type RouteParams<T> = T extends APIRoutesPaths
+  ? Parameters<(typeof APIRoutesHandlers)[T]>[1]
+  : never;
+
+type Options<T extends APIRoutesPaths> = {
   params?: RouteParams<T>;
 };
 
 /**
  * Hook to fetch data from internal API
- * @param route : route to fetch (from {@link APIPath})
+ * @param route : route to fetch (from {@link APIRoutesPaths})
  * @param slug : slug parameter for the route
  * @param session : user session, used to check rights
  * @param options : options for the fetch. **Important**: the object should be memoized, otherwise the hook will fetch the data at each render
  * @returns {IDataFetchingState | RouteResponse<T>} - The API loading state or the fetched data
  */
-export function useAPIRouteData<T extends APIPath>(
+export function useAPIRouteData<T extends APIRoutesPaths>(
   route: T,
   slug: string,
   session: ISession | null,
@@ -50,7 +56,7 @@ export function useAPIRouteData<T extends APIPath>(
   return response;
 }
 
-async function fetchAPIRoute<T extends APIPath>(
+async function fetchAPIRoute<T extends APIRoutesPaths>(
   route: T,
   slug: string,
   session: ISession | null,


### PR DESCRIPTION
- Amélioration technique.
- Zones impactées : `./app/api`.
- Détails :
  - Création d'une enum pour lister les chemin (paths) des routes

Même si typescript prévenait la possibilité de mal écrire une route, l'utilisation d'une enum évite de faire de copier/coller et permet d'utiliser l'autocomplétion.

Aussi et surtout, lorsqu'un chemin (path) est ajouté au fichier routes-paths, nous sommes désormais obligé de définir un scope pour cette route (sinon il y a une erreur typescript).

Enfin, 'espace-agent/beneficiaires' utilisait une variable dédiée, ce qui n'est plus nécessaire grâce à cette enum.

Closes #1288 
