### PR TITLE
chore: split deployment github action

### DIFF
--- a/.github/workflows/deploy-cluster-full.yml
+++ b/.github/workflows/deploy-cluster-full.yml
@@ -1,0 +1,93 @@
+name: Deployment to staging and then to production - not continuous deployment
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 7 * * *'
+
+jobs:
+  deploy-website-staging:
+    name: Deploy website to staging
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up SSH
+        run: |
+          mkdir -p ~/.ssh/
+          echo "$SSH_PRIVATE_KEY" > ./deploy.key
+          sudo chmod 600 ./deploy.key
+          ssh-keyscan -H $SSH_HOST >> ~/.ssh/known_hosts
+        shell: bash
+        env:
+          SSH_PRIVATE_KEY: ${{secrets.SSH_MACHINE_USER_PRIVATE_KEY}}
+          SSH_HOST: ${{ secrets.SSH_HOST_STAGING_V2 }}
+
+      - name: Deploy website to staging
+        run: ssh -i ./deploy.key www-data@$SSH_HOST 'python3 /opt/scripts/app-deploy-release/deploy.py /opt/git/releases/annuaire-entreprises-site https://github.com/annuaire-entreprises-data-gouv-fr/site.git website --version main --versions_to_keep=5 1> >(tee --append /var/log/deploy_annuaire-entreprises-site)'
+        env:
+          SSH_HOST: ${{ secrets.SSH_HOST_STAGING_V2 }}
+
+      - name: Notify staging failure only
+        if: failure()
+        uses: ./.github/actions/notify
+        with:
+          message: '🚨 ${{ github.event.repository.name }} : deploy to staging failed'
+          hook: ${{ secrets.TCHAP_HOOK }}
+          id: ${{ secrets.TCHAP_ROOM_ID }}
+
+  deploy-website-production:
+    name: Deploy website to production
+    runs-on: ubuntu-latest
+    needs: [deploy-website-staging]
+    timeout-minutes: 15
+    strategy:
+      matrix:
+        include:
+          - environment: production-01
+            host: SSH_PRODUCTION_01
+          - environment: production-02
+            host: SSH_PRODUCTION_02
+          - environment: production-03
+            host: SSH_PRODUCTION_03
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up SSH
+        run: |
+          mkdir -p ~/.ssh/
+          echo "$SSH_PRIVATE_KEY" > ./deploy.key
+          sudo chmod 600 ./deploy.key
+          ssh-keyscan -H $SSH_HOST >> ~/.ssh/known_hosts
+        shell: bash
+        env:
+          SSH_PRIVATE_KEY: ${{secrets.SSH_MACHINE_USER_PRIVATE_KEY}}
+          SSH_HOST: ${{ secrets[matrix.host] }}
+
+      - name: Deploy website to production
+        run: ssh -i ./deploy.key www-data@$SSH_HOST 'python3 /opt/scripts/app-deploy-release/deploy.py /opt/git/releases/annuaire-entreprises-site https://github.com/annuaire-entreprises-data-gouv-fr/site.git website --version main --versions_to_keep=5 | tee --append /var/log/deploy_annuaire-entreprises-site'
+        env:
+          SSH_HOST: ${{ secrets[matrix.host] }}
+
+      - name: Notify production failure only
+        if: failure()
+        uses: ./.github/actions/notify
+        with:
+          message: '🚨 ${{ github.event.repository.name }} [${{ matrix.environment }}] : deploy to production cluster failed'
+          hook: ${{ secrets.TCHAP_HOOK }}
+          id: ${{ secrets.TCHAP_ROOM_ID }}
+
+  notify-deploy-success:
+    name: Notify successful deployment
+    runs-on: ubuntu-latest
+    needs: [deploy-website-production]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Notify deploy success
+        uses: ./.github/actions/notify
+        with:
+          message: '✅ ${{ github.event.repository.name }} : successfully deploy production cluster'
+          hook: ${{ secrets.TCHAP_HOOK }}
+          id: ${{ secrets.TCHAP_ROOM_ID }}

--- a/.github/workflows/deploy-cluster-staging.yml
+++ b/.github/workflows/deploy-cluster-staging.yml
@@ -1,11 +1,9 @@
-name: Deploy cluster
+name: Continuous deployment to staging only
 
 on:
   push:
     branches: [main]
   workflow_dispatch:
-  schedule:
-    - cron: '0 7 * * *'
 
 jobs:
   deploy-website-staging:
@@ -36,47 +34,6 @@ jobs:
         uses: ./.github/actions/notify
         with:
           message: '🚨 ${{ github.event.repository.name }} : deploy to staging failed'
-          hook: ${{ secrets.TCHAP_HOOK }}
-          id: ${{ secrets.TCHAP_ROOM_ID }}
-
-  deploy-website-production:
-    name: Deploy website to production
-    runs-on: ubuntu-latest
-    needs: [deploy-website-staging]
-    timeout-minutes: 15
-    strategy:
-      matrix:
-        include:
-          - environment: production-01
-            host: SSH_PRODUCTION_01
-          - environment: production-02
-            host: SSH_PRODUCTION_02
-          - environment: production-03
-            host: SSH_PRODUCTION_03
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Set up SSH
-        run: |
-          mkdir -p ~/.ssh/
-          echo "$SSH_PRIVATE_KEY" > ./deploy.key
-          sudo chmod 600 ./deploy.key
-          ssh-keyscan -H $SSH_HOST >> ~/.ssh/known_hosts
-        shell: bash
-        env:
-          SSH_PRIVATE_KEY: ${{secrets.SSH_MACHINE_USER_PRIVATE_KEY}}
-          SSH_HOST: ${{ secrets[matrix.host] }}
-
-      - name: Deploy website to production
-        run: ssh -i ./deploy.key www-data@$SSH_HOST 'python3 /opt/scripts/app-deploy-release/deploy.py /opt/git/releases/annuaire-entreprises-site https://github.com/annuaire-entreprises-data-gouv-fr/site.git website --version main --versions_to_keep=5 | tee --append /var/log/deploy_annuaire-entreprises-site'
-        env:
-          SSH_HOST: ${{ secrets[matrix.host] }}
-
-      - name: Notify production failure only
-        if: failure()
-        uses: ./.github/actions/notify
-        with:
-          message: '🚨 ${{ github.event.repository.name }} [${{ matrix.environment }}] : deploy to production cluster failed'
           hook: ${{ secrets.TCHAP_HOOK }}
           id: ${{ secrets.TCHAP_ROOM_ID }}
 


### PR DESCRIPTION
Split `deploy-cluster` action into two distinct actions
- `deploy-cluster-full` : triggered with a cron, once a day or triggered manually, complete deployment 
- `deploy-cluser-staging` : triggered with a push in main, only deploy to staging