### PR TITLE
fix: add generateBuildId in next.config.js

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,6 @@
 const { withSentryConfig } = require('@sentry/nextjs');
 const redirects = require('./redirects.json');
+const nextBuildId = require('next-build-id');
 
 const WITH_SENTRY =
   !!process.env.NEXT_PUBLIC_SENTRY_DSN && process.env.NODE_ENV === 'production';
@@ -25,6 +26,8 @@ const nextjsConfig = {
     });
     return config;
   },
+  // https://github.com/nexdrew/next-build-id
+  generateBuildId: () => nextBuildId({ dir: __dirname }),
   async redirects() {
     return redirects;
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "maplibre-gl": "^4.7.1",
         "matomo-tracker": "~2.2.4",
         "next": "^14.2.3",
+        "next-build-id": "^3.0.0",
         "next-seo": "^6.6.0",
         "openid-client": "^5.7.0",
         "qrcode": "^1.5.4",
@@ -11882,6 +11883,14 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-build-id": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/next-build-id/-/next-build-id-3.0.0.tgz",
+      "integrity": "sha512-B3JCsL/9Z/wkmo3EySukQHCgx89Aw0i4LPi2MEhCboQBJ6wpkYTIu1z6hOYKuw/S1Wy8ZRqCEq0dVY/ST6jGqg==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/next-seo": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "maplibre-gl": "^4.7.1",
     "matomo-tracker": "~2.2.4",
     "next": "^14.2.3",
+    "next-build-id": "^3.0.0",
     "next-seo": "^6.6.0",
     "openid-client": "^5.7.0",
     "qrcode": "^1.5.4",


### PR DESCRIPTION
- Correction d'un bug.
- Zones impactées : `next.config.js`.
- Détails :
  - Could fix some chunk load errors

Need to be discussed.

Details from the doc of `next-build-id` :

> Why?
> If you're running multiple instances of your app sitting behind a load balancer without session affinity (and you're building your app directly on each production server instead of pre-packaging it), a tool like this is necessary to avoid Next.js errors like ["invalid build file hash"](https://github.com/zeit/next.js/blob/52ccc14059673508803f96ef1c74eecdf27fe096/server/index.js#L444), which happens when the same client (browser code) talks to multiple server backends (Node server) that have different build ids.
> 
> The build id used by your app is stored on the file system in a BUILD_ID text file in your build directory, which is .next by default.
