### PR TITLE
fix: scalingo predeploy

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -27,7 +27,9 @@ const nextjsConfig = {
     return config;
   },
   // https://github.com/nexdrew/next-build-id
-  generateBuildId: () => nextBuildId({ dir: __dirname }),
+  // if Scalingo is deploying, SOURCE_VERSION is set to be the lastest git commit hash
+  generateBuildId: () =>
+    process.env.SOURCE_VERSION || nextBuildId({ dir: __dirname }),
   async redirects() {
     return redirects;
   },

--- a/next.config.js
+++ b/next.config.js
@@ -27,7 +27,7 @@ const nextjsConfig = {
     return config;
   },
   // https://github.com/nexdrew/next-build-id
-  // if Scalingo is deploying, SOURCE_VERSION is set to be the lastest git commit hash
+  // If Scalingo is deploying, SOURCE_VERSION is set to the latest Git commit hash
   generateBuildId: () =>
     process.env.SOURCE_VERSION || nextBuildId({ dir: __dirname }),
   async redirects() {


### PR DESCRIPTION
- Correction d'un bug.
- Zones impactées : `next.config.js`.
- Détails :
  - Fallback pour scalingo pour le generateBuildId