### PR TITLE
fix: remove nofollow attribute to button

### DIFF
--- a/components/justificatifs/data-inpi-link/index.tsx
+++ b/components/justificatifs/data-inpi-link/index.tsx
@@ -48,7 +48,6 @@ export const DataInpiLinkWithExplanations = ({
       <ul className="fr-btns-group fr-btns-group--inline-md fr-btns-group--center">
         <li>
           <ButtonLink
-            nofollow={true}
             to={`/justificatif-immatriculation-pdf/${uniteLegale.siren}`}
           >
             <Icon slug="download">


### PR DESCRIPTION
- Changement mineur.
- Détails :
  - Suppression de la balise no follow du bouton "Télécharger le justificatif d'immatriculation"


<img width="754" alt="image" src="https://github.com/user-attachments/assets/19d94ffd-0b0f-4c48-8327-46aa1593d09e">

Closes https://github.com/annuaire-entreprises-data-gouv-fr/seo/issues/13