### PR TITLE
Proposition de remplacement **ville** → **commune**

### DIFF
--- a/clients/geo/communes.ts
+++ b/clients/geo/communes.ts
@@ -48,7 +48,7 @@ const mapToDomainObject = (response: IGeoCommuneResponse[]): IGeoElement[] => {
                   commune.departement?.code
                     ? ` (${commune.departement?.code})`
                     : ''
-                } - toute la ville`,
+                } — toute la commune`,
               } as IGeoElement,
             ]
           : []),


### PR DESCRIPTION
- Changement mineur.
- Zones impactées : `clients/geo/communes.ts`.
- Détails :
  - Remplacement du terme **ville** par **commune** pour les filtres de recherche, à mon sens plus adapté car le terme englobe les villages.