### PR TITLE
feat: add header to debug chunk load

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -40,6 +40,21 @@ const nextjsConfig = {
   async redirects() {
     return redirects;
   },
+  async headers() {
+    return [
+      {
+        source: '/_next/static/chunks/:path*',
+        headers: [
+          {
+            key: 'X-Debug-Chunk-Load',
+            value: `Instance-Number-${
+              process.env.INSTANCE_NUMBER
+            }-Date-${new Date().toISOString()}`,
+          },
+        ],
+      },
+    ];
+  },
 };
 
 module.exports = WITH_SENTRY


### PR DESCRIPTION
- Amélioration technique. 
- Ajout d'un header sur les chunk loads

Ajout d'un header sur les chunk loads pour identifier sur quelle instance et sur quel build (en utilisant la date de build) a été créé une réponse.
Cela permettra d'identifier si il y a un problème de mise en cache au niveau de l'infra.