### PR TITLE
chore: disable silent, add release config and remove useless lines

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -52,6 +52,15 @@ const sentryBuildOptions: SentryBuildOptions = {
   sourcemaps: {
     disable: DISABLE_SOURCEMAP_UPLOAD,
   },
+  release: {
+    create: true,
+    finalize: true,
+    name: process.env.SOURCE_VERSION,
+    setCommits: {
+      ignoreMissing: true,
+      auto: true,
+    },
+  },
 };
 
 export default WITH_SENTRY


### PR DESCRIPTION
- Changement mineur.
- Zones impactées : `next.config.ts`.
- Détails :
  - Upload des sources maps non silencieux pour debug
  - Utilisation de la fonctionnalité "release"
  - Suppression de commentaires devenus inutiles grâce à Typescript