### PR TITLE
feat: follow up proConnect/agentConnect deployment

### DIFF
--- a/app/(header-connexion)/connexion/habilitation/administration-inconnue/page.tsx
+++ b/app/(header-connexion)/connexion/habilitation/administration-inconnue/page.tsx
@@ -1,0 +1,24 @@
+import { ConnexionSubLayout } from '#components-ui/connexion-layout';
+import connexionRefusedPicture from '#components-ui/illustrations/connexion-failed';
+import constants from '#models/constants';
+import { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Votre administration est inconnue de nos services',
+  robots: 'noindex, nofollow',
+};
+
+export default function AdministrationInconnuePage() {
+  return (
+    <ConnexionSubLayout img={connexionRefusedPicture}>
+      <h1>Votre administration est inconnue de nos services</h1>
+      <p>
+        Votre administration est encore inconnue de nos services. Pouvez-vous
+        s’il vous plait{' '}
+        <a href={constants.links.parcours.contact}>nous contacter</a>, afin que
+        nous vous activions les accès ?
+      </p>
+      <a href="/">← Retourner au moteur de recherche</a>
+    </ConnexionSubLayout>
+  );
+}

--- a/app/(header-default)/dirigeants/[slug]/_component/sections/entreprise/dirigeants-open/content.tsx
+++ b/app/(header-default)/dirigeants/[slug]/_component/sections/entreprise/dirigeants-open/content.tsx
@@ -6,9 +6,9 @@ import {
   IEtatCivil,
   IPersonneMorale,
 } from '#models/rne/types';
-import { isPersonneMorale } from '../is-personne-morale';
-import EtatCivilInfos from './EtatCivilInfos';
-import PersonneMoraleInfos from './PersonneMoraleInfos';
+import { isPersonneMorale } from '../../is-personne-morale';
+import EtatCivilInfos from '../EtatCivilInfos';
+import PersonneMoraleInfos from '../PersonneMoraleInfos';
 
 type IDirigeantContentProps = {
   dirigeants: IDirigeantsWithMetadata;

--- a/app/(header-default)/dirigeants/[slug]/_component/sections/entreprise/dirigeants-open/section.tsx
+++ b/app/(header-default)/dirigeants/[slug]/_component/sections/entreprise/dirigeants-open/section.tsx
@@ -9,7 +9,7 @@ import { IUniteLegale } from '#models/core/types';
 import { ISession } from '#models/user/session';
 import { APIRoutesPaths } from 'app/api/data-fetching/routes-paths';
 import { useAPIRouteData } from 'hooks/fetch/use-API-route-data';
-import DirigeantsContent from './dirigeants-content';
+import DirigeantsContent from './content';
 
 type IProps = {
   uniteLegale: IUniteLegale;
@@ -64,7 +64,13 @@ export default function DirigeantsSection({ uniteLegale, session }: IProps) {
                     uniteLegale={uniteLegale}
                     siteName="le site de l’INPI"
                   />
-                  &nbsp;:
+                  .
+                </p>
+                <p>
+                  <strong>NB :</strong> si vous êtes agent public, vous pouvez
+                  accéder à l’etat civil complet (lieu et date de naissance
+                  complète) en vous connectant à{' '}
+                  <a href="/lp/agent-public">l’espace agent public</a>.
                 </p>
 
                 <DirigeantsContent

--- a/app/(header-default)/dirigeants/[slug]/_component/sections/entreprise/dirigeants-protected/content.tsx
+++ b/app/(header-default)/dirigeants/[slug]/_component/sections/entreprise/dirigeants-protected/content.tsx
@@ -7,9 +7,9 @@ import {
   IEtatCivilMergedIGInpi,
   IPersonneMoraleMergedIGInpi,
 } from '#models/rne/types';
-import { isPersonneMorale } from '../is-personne-morale';
-import EtatCivilInfos from './EtatCivilInfos';
-import PersonneMoraleInfos from './PersonneMoraleInfos';
+import { isPersonneMorale } from '../../is-personne-morale';
+import EtatCivilInfos from '../EtatCivilInfos';
+import PersonneMoraleInfos from '../PersonneMoraleInfos';
 
 type IDirigeantContentProps = {
   dirigeants: IDirigeantsWithMetadataMergedIGInpi;

--- a/app/(header-default)/dirigeants/[slug]/_component/sections/entreprise/dirigeants-protected/section.tsx
+++ b/app/(header-default)/dirigeants/[slug]/_component/sections/entreprise/dirigeants-protected/section.tsx
@@ -11,7 +11,7 @@ import { IUniteLegale } from '#models/core/types';
 import { ISession } from '#models/user/session';
 import { APIRoutesPaths } from 'app/api/data-fetching/routes-paths';
 import { useAPIRouteData } from 'hooks/fetch/use-API-route-data';
-import DirigeantsContentProtected from './dirigeants-content-protected';
+import DirigeantsContentProtected from './content';
 
 type IProps = {
   uniteLegale: IUniteLegale;
@@ -50,10 +50,12 @@ export default function DirigeantsSectionProtected({
         return (
           <>
             {dirigeants.metadata?.isFallback && <InpiPartiallyDownWarning />}
+
             <Info>
               Ces informations proviennent du RNE et sont issues d‘une
-              comparaison entre Infogreffe (qui procure les dates de naissance
-              complètes) et l‘INPI.
+              comparaison entre les données issues de l’
+              <INPI /> et celles d’Infogreffe (qui procure les dates de
+              naissance complètes).
             </Info>
 
             {dirigeants.data.length === 0 ? (

--- a/app/(header-default)/dirigeants/[slug]/page.tsx
+++ b/app/(header-default)/dirigeants/[slug]/page.tsx
@@ -18,8 +18,8 @@ import getSession from '#utils/server-side-helper/app/get-session';
 import { Metadata } from 'next';
 import DirigeantsAssociationSection from './_component/sections/association/dirigeants';
 import BeneficiairesSection from './_component/sections/entreprise/beneficiaires';
-import DirigeantsSection from './_component/sections/entreprise/dirigeants-section';
-import DirigeantsSectionProtected from './_component/sections/entreprise/dirigeants-section-protected';
+import DirigeantsSection from './_component/sections/entreprise/dirigeants-open/section';
+import DirigeantsSectionProtected from './_component/sections/entreprise/dirigeants-protected/section';
 import DirigeantSummary from './_component/sections/entreprise/summary';
 import ResponsablesServicePublicSection from './_component/sections/service-public';
 

--- a/app/(header-default)/labels-certificats/[slug]/page.tsx
+++ b/app/(header-default)/labels-certificats/[slug]/page.tsx
@@ -108,9 +108,13 @@ const LabelsAndCertificatsPage = async (props: AppRouterProps) => {
             <QualibatSection session={session} uniteLegale={uniteLegale} />
             <QualifelecSection session={session} uniteLegale={uniteLegale} />
             <OpqibiSection session={session} uniteLegale={uniteLegale} />
-            <CibtpSection session={session} uniteLegale={uniteLegale} />
-            <CnetpSection session={session} uniteLegale={uniteLegale} />
           </>
+        )}
+        {hasRights(session, ApplicationRights.cibtp) && (
+          <CibtpSection session={session} uniteLegale={uniteLegale} />
+        )}
+        {hasRights(session, ApplicationRights.cnetp) && (
+          <CnetpSection session={session} uniteLegale={uniteLegale} />
         )}
         {estOrganismeFormation && (
           <OrganismeDeFormationSection

--- a/app/api/auth/agent-connect/callback/route.ts
+++ b/app/api/auth/agent-connect/callback/route.ts
@@ -48,6 +48,10 @@ export const GET = withSession(async function callbackRoute(req) {
       return NextResponse.redirect(
         getBaseUrl() + '/connexion/habilitation/requise'
       );
+    } else if (e instanceof AgentConnectProviderNoSiretException) {
+      return NextResponse.redirect(
+        getBaseUrl() + '/connexion/habilitation/administration-inconnue'
+      );
     } else if (e instanceof HttpForbiddenError) {
       return NextResponse.redirect(
         getBaseUrl() + '/connexion/habilitation/refusee'

--- a/utils/session/index.ts
+++ b/utils/session/index.ts
@@ -5,7 +5,7 @@ import type { IronSession, SessionOptions } from 'iron-session';
 
 export const sessionOptions: SessionOptions = {
   password: process.env.IRON_SESSION_PWD as string,
-  cookieName: 'annuaire-entreprises-user-session',
+  cookieName: 'annuaire-entreprises-user-session-2',
   cookieOptions: {
     secure: process.env.NODE_ENV === 'production',
   },


### PR DESCRIPTION
- refactor lightly dirigeants components
- add a link to espace agent from dirigeant open
- add dedicated Administration Inconnue page
- prevent from calling API Entreprise when no siren
- force a reset of session as we now need to have a siret
- fix bug in CIBTP and CNETP rights generating 429