### PR TITLE
fix: disable all sentry build options when errors is down

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -49,9 +49,7 @@ const sentryBuildOptions: SentryBuildOptions = {
   },
   telemetry: false,
   widenClientFileUpload: true,
-  sourcemaps: {
-    disable: DISABLE_SOURCEMAP_UPLOAD,
-  },
+
   release: {
     create: true,
     finalize: true,
@@ -63,6 +61,6 @@ const sentryBuildOptions: SentryBuildOptions = {
   },
 };
 
-export default WITH_SENTRY
+export default WITH_SENTRY && !DISABLE_SOURCEMAP_UPLOAD
   ? withSentryConfig(nextConfig, sentryBuildOptions)
   : nextConfig;


### PR DESCRIPTION
- Correction d'un bug.
- Détails :
  - désactivage des fonctionnalités de sentry au build time quand errors.data.gouv.fr est hors ligne
