### PR TITLE
fix: network calls not cached

### DIFF
--- a/app/(header-default)/a-propos/stats/page.tsx
+++ b/app/(header-default)/a-propos/stats/page.tsx
@@ -3,8 +3,9 @@ import { NpsStats } from '#components/stats/nps';
 import { TraficStats } from '#components/stats/trafic';
 import { UsageStats } from '#components/stats/usage';
 import { Metadata } from 'next';
+import { unstable_cache } from 'next/cache';
 
-export const revalidate = 14400; // 4 * 3600 = 4 hours;
+export const revalidate = 43200; // 12 * 3600 = 12 hours;
 
 async function fetchStats(): Promise<IMatomoStats> {
   const {
@@ -35,7 +36,9 @@ export const metadata: Metadata = {
 
 export default async function StatsPage() {
   const { monthlyNps, visits, mostCopied, copyPasteAction, redirectedSiren } =
-    await fetchStats();
+    await unstable_cache(() => fetchStats(), ['stats'], {
+      revalidate: 43200,
+    })();
 
   return (
     <>

--- a/app/(header-default)/donnees/api/page.tsx
+++ b/app/(header-default)/donnees/api/page.tsx
@@ -7,9 +7,8 @@ import {
   getMonitorsByAdministration,
 } from '#models/monitoring';
 import { Metadata } from 'next';
+import { unstable_cache } from 'next/cache';
 import React from 'react';
-
-export const revalidate = 30;
 
 interface IProps {
   monitors: {
@@ -32,7 +31,13 @@ export const metadata: Metadata = {
 };
 
 export default async function StatusPage() {
-  const { monitors, administrationsMetaData } = await fetchStatusData();
+  const { monitors, administrationsMetaData } = await unstable_cache(
+    () => fetchStatusData(),
+    ['monitoring'],
+    {
+      revalidate: 45,
+    }
+  )();
 
   return (
     <>


### PR DESCRIPTION
- [x] fix stats and montiring page cache
- [ ] ~~migrate react's cache to next unstable cache ?~~

NB : Wont use unstable cache on cachedGetUniteLegale as it is an unstable API that might trigger a memory leak
Also unitelegale are cached on API Recherche redis