### PR TITLE
ci: manage concurrency for staging deployment workflow #1387

### DIFF
--- a/.github/workflows/deploy-cluster-staging.yml
+++ b/.github/workflows/deploy-cluster-staging.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   deploy-website-staging:
     name: Deploy website to staging


### PR DESCRIPTION
This PR processes #1387

- Amélioration technique
- Zones impactées : `.github/workflows/deploy-cluster-staging.yml`.
- Détails :
  - Cancel the staging deployment if the workflow has been triggered by a new push
