### PR TITLE
chore: add security headers on site side rather than infra

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,3 +1,4 @@
+import { getBaseUrl } from '#utils/server-side-helper/app/get-base-url';
 import { SentryBuildOptions, withSentryConfig } from '@sentry/nextjs';
 import { NextConfig } from 'next';
 import redirects from './redirects.json';
@@ -35,6 +36,56 @@ const nextConfig: NextConfig = {
   generateBuildId: () => process.env.SOURCE_VERSION || null,
   async redirects() {
     return redirects;
+  },
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: [
+          {
+            key: 'Content-Security-Policy',
+            value: [
+              "default-src 'self'",
+              "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://stats.data.gouv.fr/",
+              "style-src 'self' 'unsafe-inline'",
+              "img-src 'self' data:",
+              "frame-src 'self' https://stats.data.gouv.fr/ https://plugins.crisp.chat/",
+              "connect-src 'self' https://stats.data.gouv.fr/ https://errors.data.gouv.fr/ https://bodacc-datadila.opendatasoft.com/ https://data.economie.gouv.fr/ https://journal-officiel-datadila.opendatasoft.com/ https://api-lannuaire.service-public.fr/ https://data.culture.gouv.fr/",
+            ].join('; '),
+          },
+          {
+            key: 'Access-Control-Allow-Origin',
+            value: getBaseUrl(),
+          },
+          {
+            key: 'Access-Control-Allow-Methods',
+            value: 'GET',
+          },
+          {
+            key: 'Access-Control-Max-Age',
+            value: '86400',
+          },
+        ],
+      },
+      {
+        source: '/api/share/button:id(\\d+)',
+        headers: [
+          {
+            key: 'Access-Control-Allow-Origin',
+            value: '*',
+          },
+        ],
+      },
+      {
+        source: '/api/(feedback/nps|hide-personal-data)',
+        headers: [
+          {
+            key: 'Access-Control-Allow-Methods',
+            value: 'POST,OPTIONS',
+          },
+        ],
+      },
+    ];
   },
 };
 


### PR DESCRIPTION
As suggested by @ad2ien, writing security headers on site side allow dev to have much more control on POST routes and cross domain calls.

The alternative is to write them at nginx level and have every headers at the same place. @MKCG @rmonnier9 @ad2ien what do you think ? 


closes https://github.com/orgs/annuaire-entreprises-data-gouv-fr/projects/1/views/1?pane=issue&itemId=84349585&issue=annuaire-entreprises-data-gouv-fr%7Cinfrastructure%7C234