### PR TITLE
fix: remove injected link

### DIFF
--- a/app/(header-minimal)/formulaire/nps/page.tsx
+++ b/app/(header-minimal)/formulaire/nps/page.tsx
@@ -38,7 +38,7 @@ export const metadata = {
   title: 'Quel est votre avis sur l’Annuaire des Entreprises ?',
   robots: 'noindex, nofollow',
   alternates: {
-    canonical: 'https://annuaire-entreprises.data.gouv.fr/formulaire/merci',
+    canonical: 'https://annuaire-entreprises.data.gouv.fr/formulaire/nps',
   },
 };
 

--- a/app/api/feedback/nps/route.ts
+++ b/app/api/feedback/nps/route.ts
@@ -38,17 +38,9 @@ const logAllEvents = async (req: Request) => {
 
     // tchap : only if text
     if (text) {
-      let commentaire = text ? `\nCommentaire : ${text}` : '';
-
-      commentaire += hasEmail
-        ? `\nEmail : ${email} (<a href="mailto:${email}?subject=${encodeURIComponent(
-            `Réponse à votre message`
-          )}&body=${encodeURIComponent(
-            `Bonjour,\n Merci pour votre message : “ ${text} ” \nBonne journée,`
-          )}>répondre</a>)`
-        : '';
-
-      const tchapText = `Note : ${mood}/10 \nVisiteur : ${visitorType} \nOrigine : ${origin}${commentaire}`;
+      const tchapText = `Note : ${mood}/10 \nVisiteur : ${visitorType} \nOrigine : ${origin}\nCommentaire : ${text}${
+        hasEmail ? `\nEmail : ${email}` : ''
+      }`;
       logInTchap(tchapText);
     }
   } catch (e: any) {


### PR DESCRIPTION
- Changement mineur.
- Détails :
  - Le ternaire sur "text" est retiré car toujours vrai
  - Correction du lien canonique de /formulaire/nps 
  - Suppression du lien injecté qui ne fonctionne pas sur tchap :
 
<img width="505" alt="image" src="https://github.com/user-attachments/assets/95c4b3ea-bd9f-46b6-ab50-870d1359f599">

