### PR TITLE
ci: don't cancel workflow if concurrency as cancel  may not be handle…

### DIFF
--- a/.github/workflows/deploy-cluster-staging.yml
+++ b/.github/workflows/deploy-cluster-staging.yml
@@ -7,7 +7,6 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}
-  cancel-in-progress: true
 
 jobs:
   deploy-website-staging:


### PR DESCRIPTION
Closes #1387 (again)

Gestion des jobs concurrent en staging 

- Changement mineur.
- Zones impactées : `.github/workflows/deploy-cluster-staging.yml`.
- Détails :
  - Description dans le titre
