### PR TITLE
tests: mock updown.io while e2e tests

### DIFF
--- a/clients/api-inclusion/index.ts
+++ b/clients/api-inclusion/index.ts
@@ -9,7 +9,7 @@ import { httpGet } from '#utils/network';
  * https://lemarche.inclusion.beta.gouv.fr/api/docs/
  */
 export const clientAPIInclusion = async (siren: Siren) => {
-  const url = routes.certifications.entrepriseInclusive.api.siren + siren;
+  const url = routes.certifications.entrepriseInclusive.api.getBySiren(siren);
   const response = await httpGet<APIInclusionResponse[]>(url, {
     params: { token: process.env.API_MARCHE_INCLUSION_TOKEN },
   });

--- a/clients/monitoring/index.ts
+++ b/clients/monitoring/index.ts
@@ -25,7 +25,7 @@ export type IUpdownIODowntimes = {
 };
 
 export const clientMonitoring = async (slug: string): Promise<IMonitoring> => {
-  const url = routes.tooling.monitoring(slug);
+  const url = routes.tooling.monitoring.getBySlug(slug);
   const response = await httpGet<IUpdownIODowntimes[]>(url, {
     headers: {
       'Accept-Encoding': 'gzip',

--- a/clients/monitoring/index.ts
+++ b/clients/monitoring/index.ts
@@ -25,7 +25,7 @@ export type IUpdownIODowntimes = {
 };
 
 export const clientMonitoring = async (slug: string): Promise<IMonitoring> => {
-  const url = `${routes.tooling.monitoring}/${slug}/downtimes`;
+  const url = routes.tooling.monitoring(slug);
   const response = await httpGet<IUpdownIODowntimes[]>(url, {
     headers: {
       'Accept-Encoding': 'gzip',

--- a/clients/routes.ts
+++ b/clients/routes.ts
@@ -151,7 +151,8 @@ const routes = {
     entrepriseInclusive: {
       site: 'https://lemarche.inclusion.beta.gouv.fr/prestataires/',
       api: {
-        siren: 'https://lemarche.inclusion.beta.gouv.fr/api/siae/siren/',
+        getBySiren: (siren: string) =>
+          `https://lemarche.inclusion.beta.gouv.fr/api/siae/siren/${siren}`,
         metadata: 'https://lemarche.inclusion.beta.gouv.fr/api/siae/kinds',
       },
     },

--- a/clients/routes.ts
+++ b/clients/routes.ts
@@ -220,8 +220,10 @@ const routes = {
       },
       tracker: 'https://stats.data.gouv.fr/piwik.php',
     },
-    monitoring: (slug: string) =>
-      `https://updown.io/api/checks/${slug}/downtimes`,
+    monitoring: {
+      getBySlug: (slug: string) =>
+        `https://updown.io/api/checks/${slug}/downtimes`,
+    },
   },
 };
 

--- a/clients/routes.ts
+++ b/clients/routes.ts
@@ -219,7 +219,8 @@ const routes = {
       },
       tracker: 'https://stats.data.gouv.fr/piwik.php',
     },
-    monitoring: 'https://updown.io/api/checks/',
+    monitoring: (slug: string) =>
+      `https://updown.io/api/checks/${slug}/downtimes`,
   },
 };
 

--- a/cypress/fixtures/up-down-io.json
+++ b/cypress/fixtures/up-down-io.json
@@ -1,0 +1,11 @@
+[
+  {
+    "id": "674768b1d233cab436477906",
+    "details_url": "https://updown.io/downtimes/674768b1d233cab436477906",
+    "error": "SSL connect error",
+    "started_at": "2024-11-27T18:40:09Z",
+    "ended_at": "2024-11-27T18:50:02Z",
+    "duration": 593,
+    "partial": false
+  }
+]

--- a/cypress/mocks/handlers/up-down-io.ts
+++ b/cypress/mocks/handlers/up-down-io.ts
@@ -1,0 +1,6 @@
+import { HttpResponse, HttpResponseResolver } from 'msw';
+import upDownIo from '../../fixtures/up-down-io.json';
+
+export const upDownIoHandler: HttpResponseResolver = ({ request }) => {
+  return HttpResponse.json(upDownIo);
+};

--- a/cypress/mocks/routes.ts
+++ b/cypress/mocks/routes.ts
@@ -20,7 +20,7 @@ export const routesHandlers = [
   http.get(routes.certifications.rge.api, rgeHandler),
   http.get(routes.certifications.bio.api, apiBioHandler),
   http.get(
-    routes.certifications.entrepriseInclusive.api.siren,
+    routes.certifications.entrepriseInclusive.api.getBySiren('*'),
     apiInclusionHandler
   ),
   http.get(

--- a/cypress/mocks/routes.ts
+++ b/cypress/mocks/routes.ts
@@ -8,6 +8,7 @@ import { eoriHandler } from './handlers/eori';
 import { rechercheEntrepriseHandler } from './handlers/recherche-entreprises';
 import { rgeHandler } from './handlers/rge';
 import { tvaHandler } from './handlers/tva';
+import { upDownIoHandler } from './handlers/up-down-io';
 
 export const routesHandlers = [
   http.get(routes.proxy.tva('*'), tvaHandler),
@@ -27,4 +28,5 @@ export const routesHandlers = [
     entrepreneurSpectaclesHandler
   ),
   http.get(routes.datagouv.ess, apiDataGouvEssHandler),
+  http.get(routes.tooling.monitoring('*'), upDownIoHandler),
 ];

--- a/cypress/mocks/routes.ts
+++ b/cypress/mocks/routes.ts
@@ -28,5 +28,5 @@ export const routesHandlers = [
     entrepreneurSpectaclesHandler
   ),
   http.get(routes.datagouv.ess, apiDataGouvEssHandler),
-  http.get(routes.tooling.monitoring('*'), upDownIoHandler),
+  http.get(routes.tooling.monitoring.getBySlug('*'), upDownIoHandler),
 ];


### PR DESCRIPTION
- Amélioration technique. 
- Détails :
  - Mock updown.io while e2e tests
  - Use wildcard for api inclusion mocks
  - Remove double slash in updown.io requests :
 
<img width="731" alt="image" src="https://github.com/user-attachments/assets/e4251835-90e2-45e0-8ac7-e495cab79533">