### PR TITLE
fix(dirigeants): fix birth date from inpi/ig

### DIFF
--- a/models/espace-agent/dirigeants-protected.ts
+++ b/models/espace-agent/dirigeants-protected.ts
@@ -35,11 +35,6 @@ export const getDirigeantsProtected = async (
     return APINotRespondingFactory(EAdministration.INPI, 500);
   }
 
-  // EI can either be in RCS or not, we dont know in advance.
-  const rcsNotRelevant =
-    params.isEI &&
-    (isAPINotResponding(dirigeantsRCS) || dirigeantsRCS.length === 0);
-
   try {
     const rneData = !isAPINotResponding(dirigeantsRNE)
       ? dirigeantsRNE.data
@@ -51,13 +46,13 @@ export const getDirigeantsProtected = async (
     if (params.isEI) {
       if (rcsData.length === 0) {
         // Ignore IG
-        dirigeantMerged = mergeDirigeants(rneData, rneData);
+        dirigeantMerged = mergeDirigeants({ rne: rneData, rcs: rneData });
       } else {
         // Ignore INPI
-        dirigeantMerged = mergeDirigeants(rcsData, rcsData);
+        dirigeantMerged = mergeDirigeants({ rne: rcsData, rcs: rcsData });
       }
     } else {
-      dirigeantMerged = mergeDirigeants(rneData, rcsData);
+      dirigeantMerged = mergeDirigeants({ rne: rneData, rcs: rcsData });
     }
 
     return {

--- a/models/espace-agent/mergeDirigeants.test.ts
+++ b/models/espace-agent/mergeDirigeants.test.ts
@@ -26,7 +26,7 @@ describe('mergeDirigeants', () => {
 
     const dirigeantsRNE: IDirigeants = [];
 
-    const merged = mergeDirigeants(dirigeantsRCS, dirigeantsRNE);
+    const merged = mergeDirigeants({ rcs: dirigeantsRCS, rne: dirigeantsRNE });
 
     expect(merged).toHaveLength(1);
     expect(merged[0]).toEqual(
@@ -65,7 +65,7 @@ describe('mergeDirigeants', () => {
       },
     ];
 
-    const merged = mergeDirigeants(dirigeantsRCS, dirigeantsRNE);
+    const merged = mergeDirigeants({ rcs: dirigeantsRCS, rne: dirigeantsRNE });
 
     expect(merged).toHaveLength(1);
     expect(merged[0]).toEqual(
@@ -103,7 +103,7 @@ describe('mergeDirigeants', () => {
 
     const dirigeantsRNE: IDirigeants = [];
 
-    const merged = mergeDirigeants(dirigeantsRCS, dirigeantsRNE);
+    const merged = mergeDirigeants({ rcs: dirigeantsRCS, rne: dirigeantsRNE });
 
     expect(merged).toHaveLength(1);
     expect(merged[0]).toEqual(
@@ -141,7 +141,7 @@ describe('mergeDirigeants', () => {
       },
     ];
 
-    const merged = mergeDirigeants(dirigeantsRCS, dirigeantsRNE);
+    const merged = mergeDirigeants({ rcs: dirigeantsRCS, rne: dirigeantsRNE });
 
     expect(merged).toHaveLength(1);
     expect(merged[0]).toEqual(
@@ -179,7 +179,7 @@ describe('mergeDirigeants', () => {
       },
     ];
 
-    const merged = mergeDirigeants(dirigeantsRCS, dirigeantsRNE);
+    const merged = mergeDirigeants({ rcs: dirigeantsRCS, rne: dirigeantsRNE });
 
     expect(merged).toHaveLength(1);
     expect(merged[0]).toEqual(
@@ -214,7 +214,7 @@ describe('mergeDirigeants', () => {
       },
     ];
 
-    const merged = mergeDirigeants(dirigeantsRCS, dirigeantsRNE);
+    const merged = mergeDirigeants({ rcs: dirigeantsRCS, rne: dirigeantsRNE });
 
     expect(merged).toHaveLength(2);
     expect(merged).toEqual(
@@ -259,7 +259,7 @@ describe('mergeDirigeants', () => {
       },
     ];
 
-    const merged = mergeDirigeants(dirigeantsRCS, dirigeantsRNE);
+    const merged = mergeDirigeants({ rcs: dirigeantsRCS, rne: dirigeantsRNE });
 
     expect(merged).toHaveLength(2);
     expect(merged).toEqual(

--- a/models/espace-agent/utils.ts
+++ b/models/espace-agent/utils.ts
@@ -53,10 +53,13 @@ const createUniqueKey = (dirigeant: IEtatCivil | IPersonneMorale): string => {
   }
 };
 
-export const mergeDirigeants = (
-  dirigeantsRCS: IDirigeants,
-  dirigeantsRNE: IDirigeants
-): IDirigeantsMergedIGInpi => {
+export const mergeDirigeants = ({
+  rne: dirigeantsRNE,
+  rcs: dirigeantsRCS,
+}: {
+  rne: IDirigeants;
+  rcs: IDirigeants;
+}): IDirigeantsMergedIGInpi => {
   const mergedDirigeants: Record<
     string,
     IEtatCivilMergedIGInpi | IPersonneMoraleMergedIGInpi

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -3,4 +3,4 @@
 /// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
- Correction d'un bug. 
- Détails :
  - Les dates de naissance complètes ne s'affichent pas pour les agents connectés.
  - Cela est du à une inversion des données du RCS et du RNE en entrée de mergeDirigeants : nous utilisons maintenant des variables nommées.
  - Suppression du booléen inutilisé rcsNotRelevant

