### PR TITLE
fix: effectif cell when 404

### DIFF
--- a/app/(header-default)/entreprise/[slug]/_components/effectif-cell.tsx
+++ b/app/(header-default)/entreprise/[slug]/_components/effectif-cell.tsx
@@ -27,7 +27,7 @@ export const FAQEffectifAnnuel = () => (
   </FAQLink>
 );
 
-export const EffectifProtected = ({
+export const ProtectedEffectifCell = ({
   uniteLegale,
   session,
 }: {
@@ -42,15 +42,15 @@ export const EffectifProtected = ({
 
   if (isDataLoading(effectifsAnnuelsProtected)) {
     return (
-      <>
+      <ProtectedInlineData>
         <Loader />
         &nbsp;
-      </>
+      </ProtectedInlineData>
     );
   }
 
   if (isAPI404(effectifsAnnuelsProtected)) {
-    return null;
+    return <ProtectedInlineData>Pas de données</ProtectedInlineData>;
   }
 
   if (hasAnyError(effectifsAnnuelsProtected)) {
@@ -76,23 +76,9 @@ export const EffectifProtected = ({
 
   const { effectif, anneeEffectif } = effectifsAnnuelsProtected;
   return (
-    <ul>
-      <li>
-        Tranche statistique (<INSEE />) :{' '}
-        {libelleTrancheEffectif(
-          uniteLegale.trancheEffectif,
-          uniteLegale.anneeTrancheEffectif
-        )}
-      </li>
-      <li>
-        <span>
-          <FAQEffectifAnnuel /> (<GIPMDS />) :{' '}
-        </span>
-        <ProtectedInlineData>
-          {effectif} salarié{effectif > 1 ? 's' : ''}, en {anneeEffectif}
-        </ProtectedInlineData>
-      </li>
-    </ul>
+    <ProtectedInlineData>
+      {effectif} salarié{effectif > 1 ? 's' : ''}, en {anneeEffectif}
+    </ProtectedInlineData>
   );
 };
 
@@ -104,7 +90,23 @@ export const EffectifCell = ({
   session: ISession | null;
 }) => {
   if (hasRights(session, ApplicationRights.effectifsAnnuels)) {
-    return <EffectifProtected uniteLegale={uniteLegale} session={session} />;
+    return (
+      <ul>
+        <li>
+          Tranche statistique (<INSEE />) :{' '}
+          {libelleTrancheEffectif(
+            uniteLegale.trancheEffectif,
+            uniteLegale.anneeTrancheEffectif
+          )}
+        </li>
+        <li>
+          <span>
+            <FAQEffectifAnnuel /> (<GIPMDS />) :{' '}
+          </span>
+          <ProtectedEffectifCell uniteLegale={uniteLegale} session={session} />
+        </li>
+      </ul>
+    );
   }
   const effectif = libelleTrancheEffectif(
     uniteLegale.trancheEffectif,


### PR DESCRIPTION
- Correction d'un bug.
- Détails :
  - Quand il y avait un 404 pour la donnée protégée, rien ne s'affichait

Loader :
<img width="1010" alt="image" src="https://github.com/user-attachments/assets/709a1e4c-1d82-4008-b687-26c6f7ed0a5c" />

404 : 
<img width="971" alt="image" src="https://github.com/user-attachments/assets/d5933fe4-f3b1-4121-a988-8314ed08746e" />

Erreur : 
<img width="939" alt="image" src="https://github.com/user-attachments/assets/440f086a-db82-42d9-a016-e7ccdc8414b0" />

Good :
<img width="1047" alt="image" src="https://github.com/user-attachments/assets/3bee1a39-0b3e-4538-ac16-d692cf2918e3" />



