### PR TITLE
feat: replace grist with github for super-agents

### DIFF
--- a/clients/authentication/super-agent-scopes/index.ts
+++ b/clients/authentication/super-agent-scopes/index.ts
@@ -1,6 +1,6 @@
 import { FetchRessourceException } from '#models/exceptions';
 import { IAgentScope, isAgentScope } from '#models/user/scopes';
-import { readFromGrist } from '#utils/integrations/grist';
+import { readFromGithub } from '#utils/integrations/github';
 import { logFatalErrorInSentry } from '#utils/sentry';
 
 class SuperAgentsScopes {
@@ -11,7 +11,7 @@ class SuperAgentsScopes {
   getScope = async (email: string) => {
     if (Object.keys(this._scopesPerAgents).length === 0) {
       try {
-        const superAgents = await readFromGrist('comptes-agents');
+        const superAgents = await readFromGithub();
 
         superAgents
           .filter((r: any) => r.actif === true)

--- a/utils/integrations/github.ts
+++ b/utils/integrations/github.ts
@@ -1,0 +1,47 @@
+import constants from '#models/constants';
+import { Exception } from '#models/exceptions';
+import httpClient from '#utils/network';
+import logErrorInSentry from '#utils/sentry';
+
+const owner = 'annuaire-entreprises-data-gouv-fr';
+const repo = 'secret_repository_name';
+const filePath = 'super-agents.json';
+const branch = 'main';
+const token = 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
+
+interface GithubContentResponse {
+  content: string;
+}
+
+export async function readFromGithub() {
+  const url = `https://api.github.com/repos/${owner}/${repo}/contents/${filePath}?ref=${branch}`;
+
+  try {
+    const response = await httpClient<GithubContentResponse>({
+      method: 'GET',
+      url,
+      headers: {
+        Authorization: `token ${token}`,
+      },
+      timeout: constants.timeout.XXL,
+    });
+
+    const decodedContent = Buffer.from(response.content, 'base64').toString(
+      'utf-8'
+    );
+
+    return JSON.parse(decodedContent);
+  } catch (error) {
+    logErrorInSentry(new ReadFromGithubException({ cause: error }));
+    throw error;
+  }
+}
+
+class ReadFromGithubException extends Exception {
+  constructor(args: { cause?: any }) {
+    super({
+      ...args,
+      name: 'ReadFromGithubException',
+    });
+  }
+}


### PR DESCRIPTION
Proposition pou remplacer Grist par Github.

Il faut paramétrer les secrest / repos.

Inconvénient : la liste est difficile à modifier en JSON pour un profil non technique.