### PR TITLE
fix: check right before rendering bilans section

### DIFF
--- a/app/(header-default)/donnees-financieres/[slug]/page.tsx
+++ b/app/(header-default)/donnees-financieres/[slug]/page.tsx
@@ -72,12 +72,13 @@ const FinancePage = async (props: AppRouterProps) => {
                   uniteLegale={uniteLegale}
                   session={session}
                 />
-                {isMoreThanThreeYearsOld && (
-                  <FinancesSocieteBilansSection
-                    uniteLegale={uniteLegale}
-                    session={session}
-                  />
-                )}
+                {hasRights(session, ApplicationRights.bilans) &&
+                  isMoreThanThreeYearsOld && (
+                    <FinancesSocieteBilansSection
+                      uniteLegale={uniteLegale}
+                      session={session}
+                    />
+                  )}
               </>
             ) : (
               <DonneesPriveesSection title="Indicateurs financiers" />


### PR DESCRIPTION
Avoid unnecessary rendering when no right.
