### PR TITLE
fix: format number effectifs

### DIFF
--- a/app/(header-default)/entreprise/[slug]/_components/effectif-cell.tsx
+++ b/app/(header-default)/entreprise/[slug]/_components/effectif-cell.tsx
@@ -12,6 +12,7 @@ import { IUniteLegale } from '#models/core/types';
 import { hasAnyError, isDataLoading } from '#models/data-fetching';
 import { ApplicationRights, hasRights } from '#models/user/rights';
 import { ISession } from '#models/user/session';
+import { formatFloatFr } from '#utils/helpers';
 import { libelleTrancheEffectif } from '#utils/helpers/formatting/codes-effectifs';
 import { APIRoutesPaths } from 'app/api/data-fetching/routes-paths';
 import { useAPIRouteData } from 'hooks/fetch/use-API-route-data';
@@ -77,7 +78,8 @@ export const ProtectedEffectifCell = ({
   const { effectif, anneeEffectif } = effectifsAnnuelsProtected;
   return (
     <ProtectedInlineData>
-      {effectif} salarié{effectif > 1 ? 's' : ''}, en {anneeEffectif}
+      {formatFloatFr(effectif.toString())} salarié{effectif > 1 ? 's' : ''}, en{' '}
+      {anneeEffectif}
     </ProtectedInlineData>
   );
 };


### PR DESCRIPTION
- Amélioration technique.
- Détails :
  - Formattage de "Effectif annuel" en locale française

Avant :
<img width="542" alt="image" src="https://github.com/user-attachments/assets/3e38be2e-1096-4203-8eea-b4995ccfc13a" />

Après :
<img width="521" alt="image" src="https://github.com/user-attachments/assets/aacd79ce-d191-4410-8361-1ec99ccbb2d2" />
