### PR TITLE
fix(external-api-test): sign commits 2

### DIFF
--- a/.github/workflows/external-api-test.yml
+++ b/.github/workflows/external-api-test.yml
@@ -61,8 +61,6 @@ jobs:
 
       - name: 'Create a PR if there is a diff in the snapshots'
         uses: peter-evans/create-pull-request@v6
-        env:
-          GITHUB_TOKEN: ${{ secrets.TOKEN_GITHUB_EXTERNAL_API_TEST_PR }}
         with:
           branch: 'BOT-snapshots-update'
           title: '🤖 API client snapshots update'


### PR DESCRIPTION
Deuxième tentative pour signer les commits faits par le bot.

Documentation de `peter-evans/create-pull-request@v7` : "In this example the token input is not supplied, so the action will use the repository's default GITHUB_TOKEN. This will sign commits as github-actions[bot]."

<img width="1091" alt="image" src="https://github.com/user-attachments/assets/73580b32-411a-4787-a9d6-8f7a9bbcaa05" />

