### PR TITLE
fix: remove secrets for e2e tests and external api tests

### DIFF
--- a/.github/workflows/external-api-test.yml
+++ b/.github/workflows/external-api-test.yml
@@ -12,18 +12,6 @@ on:
 # For critical env variable, declare it within the action.
 env:
   node-version: 18.x
-  INSEE_USERNAME: ${{ secrets.INSEE_USERNAME }}
-  INSEE_PASSWORD: ${{ secrets.INSEE_PASSWORD }}
-  INSEE_CLIENT_ID: ${{ secrets.INSEE_CLIENT_ID }}
-  INSEE_CLIENT_SECRET: ${{ secrets.INSEE_CLIENT_SECRET}}
-  INSEE_CLIENT_ID_FALLBACK: ${{ secrets.INSEE_CLIENT_ID_FALLBACK }}
-  INSEE_CLIENT_SECRET_FALLBACK: ${{ secrets.INSEE_CLIENT_SECRET_FALLBACK}}
-  NEXT_PUBLIC_END2END_MOCKING: disabled
-  INDEXING_ENABLED: enabled
-  REDIS_ENABLED: disabled
-  PROXY_API_KEY: ${{ secrets.PROXY_API_KEY }}
-  IRON_SESSION_PWD: ${{ secrets.IRON_SESSION_PWD }}
-  GRIST_API_KEY: ${{ secrets.GRIST_API_KEY }}
 
 jobs:
   dependencies:

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -17,12 +17,10 @@ env:
   INSEE_CLIENT_ID_FALLBACK: ${{ secrets.INSEE_CLIENT_ID_FALLBACK }}
   INSEE_CLIENT_SECRET_FALLBACK: ${{ secrets.INSEE_CLIENT_SECRET_FALLBACK}}
   INDEXING_ENABLED: enabled
-  REDIS_ENABLED: disabled
   MATOMO_ENABLED: disabled
   MATOMO_SITE_ID: ${{ secrets.MATOMO_SITE_ID }}
   MATOMO_API_SITE_ID: ${{ secrets.MATOMO_API_SITE_ID }}
-  PROXY_API_KEY: ${{ secrets.PROXY_API_KEY }}
-  IRON_SESSION_PWD: ${{ secrets.IRON_SESSION_PWD }}
+  IRON_SESSION_PWD: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
   GRIST_API_KEY: ${{ secrets.GRIST_API_KEY }}
   UPDOWN_IO_API_KEY: ${{ secrets.UPDOWN_IO_API_KEY }}
 
@@ -101,13 +99,8 @@ jobs:
     env:
       NEXT_PUBLIC_END2END_MOCKING: enabled
       NEXT_PUBLIC_BASE_URL: http://localhost:3000
-      AGENTCONNECT_CLIENT_ID: ${{ secrets.AGENTCONNECT_CLIENT_ID }}
-      AGENTCONNECT_CLIENT_SECRET: ${{ secrets.AGENTCONNECT_CLIENT_SECRET }}
-      AGENTCONNECT_URL_DISCOVER: https://fca.integ01.dev-agentconnect.fr/api/v2/.well-known/openid-configuration
-      AGENTCONNECT_REDIRECT_URI: http://localhost:3000/api/auth/agent-connect/callback
-      AGENTCONNECT_POST_LOGOUT_REDIRECT_URI: http://localhost:3000/api/auth/agent-connect/logout-callback
-      API_ENTREPRISE_TOKEN: ${{ secrets.API_ENTREPRISE_TOKEN }}
-      API_ENTREPRISE_URL: ${{ secrets.API_ENTREPRISE_URL }}
+      API_ENTREPRISE_URL: http://uselessurl.com
+      API_ENTREPRISE_TOKEN: XXXXXX
     steps:
       - name: Checkout 🛎
         uses: actions/checkout@v4
@@ -130,7 +123,7 @@ jobs:
           record: false
           config-file: ./cypress/cypress.config.ts
         env:
-          CYPRESS_IRON_SESSION_PWD: ${{ secrets.IRON_SESSION_PWD }}
+          CYPRESS_IRON_SESSION_PWD: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
       - name: Upload screenshots 📸
         uses: actions/upload-artifact@v4
         # add the line below to store screenshots only on failures


### PR DESCRIPTION
Grâce au serveur de mocks pour les tests end to end, on a vraiment plus besoin de secrets pour les faire 😎
