### PR TITLE
refacto(api entreprise client): use url env var in the client

### DIFF
--- a/clients/api-entreprise/association/index.ts
+++ b/clients/api-entreprise/association/index.ts
@@ -11,12 +11,7 @@ export async function clientApiEntrepriseAssociation(siren: Siren) {
   return await clientAPIEntreprise<
     IAPIEntrepriseAssociation,
     IAssociationProtected
-  >(
-    `${process.env.API_ENTREPRISE_URL}${routes.apiEntreprise.association(
-      siren
-    )}`,
-    mapToDomainObject
-  );
+  >(routes.apiEntreprise.association(siren), mapToDomainObject);
 }
 
 const mapToDomainObject = (

--- a/clients/api-entreprise/beneficiaires/index.ts
+++ b/clients/api-entreprise/beneficiaires/index.ts
@@ -32,13 +32,7 @@ export const clientApiEntrepriseBeneficiaires = async (
   return await clientAPIEntreprise<
     IAPIEntrepriseBeneficiaires,
     Array<IBeneficiairesEffectif>
-  >(
-    `${process.env.API_ENTREPRISE_URL}${routes.apiEntreprise.beneficiaires(
-      siren
-    )}`,
-    mapToDomainObject,
-    { useCase }
-  );
+  >(routes.apiEntreprise.beneficiaires(siren), mapToDomainObject, { useCase });
 };
 
 const mapToDomainObject = (

--- a/clients/api-entreprise/bilans/index.ts
+++ b/clients/api-entreprise/bilans/index.ts
@@ -11,12 +11,7 @@ export async function clientApiEntrepriseBilans(siren: Siren) {
   return await clientAPIEntreprise<
     IAPIEntrepriseBanqueDeFranceBilans,
     IBilansProtected
-  >(
-    `${
-      process.env.API_ENTREPRISE_URL
-    }${routes.apiEntreprise.banqueDeFrance.bilans(siren)}`,
-    mapToDomainObject
-  );
+  >(routes.apiEntreprise.banqueDeFrance.bilans(siren), mapToDomainObject);
 }
 const mapToDomainObject = (
   response: IAPIEntrepriseBanqueDeFranceBilans

--- a/clients/api-entreprise/certificats/qualibat.ts
+++ b/clients/api-entreprise/certificats/qualibat.ts
@@ -31,9 +31,7 @@ export type IAPIEntrepriseQualibat = IAPIEntrepriseResponse<{
  */
 export const clientApiEntrepriseQualibat = async (siret: Siret) => {
   return await clientAPIEntreprise(
-    `${
-      process.env.API_ENTREPRISE_URL
-    }${routes.apiEntreprise.certifications.qualibat(siret)}`,
+    routes.apiEntreprise.certifications.qualibat(siret),
     mapToDomainObject
   );
 };

--- a/clients/api-entreprise/certificats/qualifelec.ts
+++ b/clients/api-entreprise/certificats/qualifelec.ts
@@ -53,9 +53,7 @@ export type IAPIEntrepriseQualifelec = IAPIEntrepriseResponse<
  */
 export const clientApiEntrepriseQualifelec = async (siret: Siret) => {
   return await clientAPIEntreprise<IAPIEntrepriseQualifelec, IQualifelec>(
-    `${
-      process.env.API_ENTREPRISE_URL
-    }${routes.apiEntreprise.certifications.qualifelec(siret)}`,
+    routes.apiEntreprise.certifications.qualifelec(siret),
     mapToDomainObject
   );
 };

--- a/clients/api-entreprise/chiffres-affaires/index.ts
+++ b/clients/api-entreprise/chiffres-affaires/index.ts
@@ -12,12 +12,7 @@ export async function clientApiEntrepriseChiffreAffaires(siret: Siret) {
   return await clientAPIEntreprise<
     IAPIEntrepriseChiffreAffaires,
     IChiffreAffairesProtected
-  >(
-    `${
-      process.env.API_ENTREPRISE_URL
-    }${routes.apiEntreprise.dgfip.chiffreAffaires(siret)}`,
-    mapToDomainObject
-  );
+  >(routes.apiEntreprise.dgfip.chiffreAffaires(siret), mapToDomainObject);
 }
 
 const mapToDomainObject = (

--- a/clients/api-entreprise/client.ts
+++ b/clients/api-entreprise/client.ts
@@ -44,7 +44,8 @@ export default async function clientAPIEntreprise<T, U>(
     throw new HttpUnauthorizedError('Missing API Entreprise credentials');
   }
 
-  const response = await httpGet<T>(route, {
+  const url = `${process.env.API_ENTREPRISE_URL}${route}`;
+  const response = await httpGet<T>(url, {
     headers: {
       Authorization: `Bearer ${process.env.API_ENTREPRISE_TOKEN}`,
     },

--- a/clients/api-entreprise/conformite/fiscale.ts
+++ b/clients/api-entreprise/conformite/fiscale.ts
@@ -21,13 +21,9 @@ export const clientApiEntrepriseConformiteFiscale = async (
   return await clientAPIEntreprise<
     IAPIEntrepriseConformiteFiscale,
     IConformite
-  >(
-    `${process.env.API_ENTREPRISE_URL}${routes.apiEntreprise.conformite.fiscale(
-      siren
-    )}`,
-    mapToDomainObject,
-    { useCase }
-  );
+  >(routes.apiEntreprise.conformite.fiscale(siren), mapToDomainObject, {
+    useCase,
+  });
 };
 
 const mapToDomainObject = (response: IAPIEntrepriseConformiteFiscale) => {

--- a/clients/api-entreprise/conformite/msa.ts
+++ b/clients/api-entreprise/conformite/msa.ts
@@ -16,9 +16,7 @@ export const clientApiEntrepriseConformiteMSA = async (
   useCase: UseCase
 ) => {
   return await clientAPIEntreprise<IAPIEntrepriseConformiteMSA, IConformite>(
-    `${process.env.API_ENTREPRISE_URL}${routes.apiEntreprise.conformite.msa(
-      siret
-    )}`,
+    routes.apiEntreprise.conformite.msa(siret),
     mapToDomainObject,
     { useCase }
   );

--- a/clients/api-entreprise/conformite/vigilance.ts
+++ b/clients/api-entreprise/conformite/vigilance.ts
@@ -26,13 +26,9 @@ export const clientApiEntrepriseConformiteVigilance = async (
   return await clientAPIEntreprise<
     IAPIEntrepriseConformiteVigilance,
     IConformite
-  >(
-    `${
-      process.env.API_ENTREPRISE_URL
-    }${routes.apiEntreprise.conformite.vigilance(siren)}`,
-    mapToDomainObject,
-    { useCase }
-  );
+  >(routes.apiEntreprise.conformite.vigilance(siren), mapToDomainObject, {
+    useCase,
+  });
 };
 
 const mapToDomainObject = (response: IAPIEntrepriseConformiteVigilance) => {

--- a/clients/api-entreprise/effectifs/annuels.ts
+++ b/clients/api-entreprise/effectifs/annuels.ts
@@ -14,13 +14,7 @@ export async function clientApiEntrepriseEffectifsAnnuels(
   return await clientAPIEntreprise<
     IAPIEntrepriseRcpEffectifsAnnuels,
     IEffectifsAnnuelsProtected
-  >(
-    `${process.env.API_ENTREPRISE_URL}${routes.apiEntreprise.effectifs.annuels(
-      siren,
-      year
-    )}`,
-    mapToDomainObject
-  );
+  >(routes.apiEntreprise.effectifs.annuels(siren, year), mapToDomainObject);
 }
 
 const mapToDomainObject = ({

--- a/clients/api-entreprise/mandataires-rcs/index.ts
+++ b/clients/api-entreprise/mandataires-rcs/index.ts
@@ -40,9 +40,7 @@ export type IAPIEntrepriseMandatairesRCS = IAPIEntrepriseResponse<
  */
 export const clientApiEntrepriseMandatairesRCS = async (siren: Siren) => {
   return await clientAPIEntreprise<IAPIEntrepriseMandatairesRCS, IDirigeants>(
-    `${process.env.API_ENTREPRISE_URL}${routes.apiEntreprise.mandatairesRCS(
-      siren
-    )}`,
+    routes.apiEntreprise.mandatairesRCS(siren),
     mapToDomainObject
   );
 };

--- a/clients/api-entreprise/opqibi/index.ts
+++ b/clients/api-entreprise/opqibi/index.ts
@@ -30,9 +30,7 @@ export type IAPIEntrepriseOpqibi = IAPIEntrepriseResponse<{
  */
 export const clientApiEntrepriseOpqibi = async (siren: Siren) => {
   return await clientAPIEntreprise(
-    `${
-      process.env.API_ENTREPRISE_URL
-    }${routes.apiEntreprise.certifications.opqibi(siren)}`,
+    routes.apiEntreprise.certifications.opqibi(siren),
     mapToDomainObject
   );
 };

--- a/clients/api-entreprise/travaux-publics/index.ts
+++ b/clients/api-entreprise/travaux-publics/index.ts
@@ -17,9 +17,7 @@ export const clientApiEntrepriseCibtp = async (
   useCase: UseCase
 ) => {
   return await clientAPIEntreprise(
-    `${
-      process.env.API_ENTREPRISE_URL
-    }${routes.apiEntreprise.certifications.cibtp(siret)}`,
+    routes.apiEntreprise.certifications.cibtp(siret),
     mapToDomainObject,
     { useCase }
   );
@@ -33,9 +31,7 @@ export const clientApiEntrepriseProbtp = async (
   useCase: UseCase
 ) => {
   return await clientAPIEntreprise(
-    `${
-      process.env.API_ENTREPRISE_URL
-    }${routes.apiEntreprise.certifications.probtp(siret)}`,
+    routes.apiEntreprise.certifications.probtp(siret),
     mapToDomainObject,
     { useCase }
   );
@@ -49,9 +45,7 @@ export const clientApiEntrepriseCnetp = async (
   useCase: UseCase
 ) => {
   return await clientAPIEntreprise(
-    `${
-      process.env.API_ENTREPRISE_URL
-    }${routes.apiEntreprise.certifications.cnetp(siren)}`,
+    routes.apiEntreprise.certifications.cnetp(siren),
     mapToDomainObject,
     { useCase }
   );
@@ -65,9 +59,7 @@ export const clientApiEntrepriseCarteProfessionnelleTravauxPublics = async (
   useCase: UseCase
 ) => {
   return await clientAPIEntreprise(
-    `${
-      process.env.API_ENTREPRISE_URL
-    }${routes.apiEntreprise.carteProfessionnelleTravauxPublics(siren)}`,
+    routes.apiEntreprise.carteProfessionnelleTravauxPublics(siren),
     mapToDomainObject,
     { useCase }
   );


### PR DESCRIPTION
- Refacto
- Détails :
  - Le client api entreprise récupère une route plutôt qu'une URL
  - L'URL est construite dans le client à partir de process.env.API_ENTREPRISE_URL

