### PR TITLE
feat: remove whitespace in siret from ProConnect

### DIFF
--- a/app/api/auth/agent-connect/callback/route.ts
+++ b/app/api/auth/agent-connect/callback/route.ts
@@ -18,7 +18,7 @@ export const GET = withSession(async function callbackRoute(req) {
   let siretStr = '';
   try {
     const userInfo = await proConnectAuthenticate(req);
-    siretStr = (userInfo.siret || '').replaceAll(' ', '');
+    siretStr = userInfo.siret;
 
     if (!userInfo.siret) {
       logInfoInSentry(

--- a/app/api/auth/agent-connect/callback/route.ts
+++ b/app/api/auth/agent-connect/callback/route.ts
@@ -18,7 +18,7 @@ export const GET = withSession(async function callbackRoute(req) {
   let siretStr = '';
   try {
     const userInfo = await proConnectAuthenticate(req);
-    siretStr = userInfo.siret;
+    siretStr = (userInfo.siret || '').replaceAll(' ', '');
 
     if (!userInfo.siret) {
       logInfoInSentry(

--- a/models/authentication/agent/index.ts
+++ b/models/authentication/agent/index.ts
@@ -34,7 +34,9 @@ export class AgentConnected {
     this.familyName = userInfo.family_name ?? '';
     this.firstName = userInfo.given_name ?? '';
     this.userId = userInfo.sub;
-    this.siret = userInfo.siret || getSiretFromIdpTemporary(this.idpId);
+    this.siret = (
+      userInfo.siret || getSiretFromIdpTemporary(this.idpId)
+    ).replaceAll(' ', '');
   }
 
   extractDomain(email: string) {


### PR DESCRIPTION
Following yesterday deployment of siretisation by ProConnect, PC may return inconsistent siret format

This triggers a `NotASiretError` and fails connection (probably explains the MCAS case) 