### PR TITLE
feat: add copy paste for siren

### DIFF
--- a/components/table/copy-paste.module.css
+++ b/components/table/copy-paste.module.css
@@ -18,11 +18,20 @@
   text-align: left;
 }
 
-.tooltipDisabled:hover {
+.copyIconDisabled:hover {
+  border-radius: 3px;
+}
+
+.copyIconDisabled:hover {
   background-color: var(--annuaire-colors-pastelBlue) !important;
 }
 
-.copyTooltip {
+.copyIconDisabled:active {
+  filter: brightness(0.9);
+  background-color: var(--annuaire-colors-pastelBlue) !important;
+}
+
+.copyIcon {
   background-color: var(--annuaire-colors-pastelBlue);
   border-radius: 3px;
   color: var(--annuaire-colors-frBlue);
@@ -34,7 +43,7 @@
   will-change: transform, opacity;
 }
 
-.copyTooltipAbsolute {
+.copyIconAbsolute {
   position: absolute;
   bottom: 0;
   right: 0;

--- a/components/table/copy-paste.module.css
+++ b/components/table/copy-paste.module.css
@@ -18,6 +18,10 @@
   text-align: left;
 }
 
+.tooltipDisabled:hover {
+  background-color: var(--annuaire-colors-pastelBlue) !important;
+}
+
 .copyTooltip {
   background-color: var(--annuaire-colors-pastelBlue);
   border-radius: 3px;

--- a/components/table/copy-paste.tsx
+++ b/components/table/copy-paste.tsx
@@ -4,7 +4,7 @@ import { useLayoutEffect, useRef, useState } from 'react';
 import style from './copy-paste.module.css';
 
 type ICopyPasteProps = {
-  disableTooltip?: boolean;
+  disableCopyIcon?: boolean;
   shouldRemoveSpace?: boolean;
   id?: string;
   children: string;
@@ -22,7 +22,7 @@ function copyFallback(value: string) {
 export function CopyPaste({
   children,
   shouldRemoveSpace = false,
-  disableTooltip = false,
+  disableCopyIcon = false,
   id = undefined,
   label,
 }: ICopyPasteProps) {
@@ -72,18 +72,18 @@ export function CopyPaste({
   const [copied, setCopied] = useState(false);
   const [focused, setFocused] = useState(false);
 
-  const copyTooltipRef = useRef<HTMLSpanElement>(null);
+  const copyIconRef = useRef<HTMLSpanElement>(null);
 
   useLayoutEffect(() => {
-    if (copyTooltipRef.current && copyTooltipRef.current.offsetTop > 0) {
-      copyTooltipRef.current.classList.add(style.copyTooltipAbsolute);
+    if (copyIconRef.current && copyIconRef.current.offsetTop > 0) {
+      copyIconRef.current.classList.add(style.copyTooltipAbsolute);
     }
   });
 
   return (
     <button
       className={`${style.copyButton} ${
-        disableTooltip ? style.tooltipDisabled : ''
+        disableCopyIcon ? style.copyIconDisabled : ''
       }`}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
@@ -92,14 +92,14 @@ export function CopyPaste({
       ref={element}
       onClick={copyToClipboard}
       aria-label={`${children}, copier dans le presse-papier`}
-      title="Copier dans le presse-papier"
+      title="Cliquez pour copier dans le presse-papier"
     >
       <span id={id}>{children} </span>
-      {(hovered || copied || focused) && !disableTooltip && (
+      {(hovered || copied || focused) && !disableCopyIcon && (
         <span
-          className={style.copyTooltip}
+          className={style.copyIcon}
           aria-hidden
-          ref={copyTooltipRef}
+          ref={copyIconRef}
           style={{ color: copied ? 'green' : '' }}
         >
           {copied ? (

--- a/components/table/copy-paste.tsx
+++ b/components/table/copy-paste.tsx
@@ -1,9 +1,10 @@
 'use client';
-import { useLayoutEffect, useRef, useState } from 'react';
 import { InternalError } from '#models/exceptions';
+import { useLayoutEffect, useRef, useState } from 'react';
 import style from './copy-paste.module.css';
 
 type ICopyPasteProps = {
+  disableTooltip?: boolean;
   shouldRemoveSpace?: boolean;
   id?: string;
   children: string;
@@ -21,6 +22,7 @@ function copyFallback(value: string) {
 export function CopyPaste({
   children,
   shouldRemoveSpace = false,
+  disableTooltip = false,
   id = undefined,
   label,
 }: ICopyPasteProps) {
@@ -80,7 +82,9 @@ export function CopyPaste({
 
   return (
     <button
-      className={style.copyButton}
+      className={`${style.copyButton} ${
+        disableTooltip ? style.tooltipDisabled : ''
+      }`}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
       onFocus={() => setFocused(true)}
@@ -91,7 +95,7 @@ export function CopyPaste({
       title="Copier dans le presse-papier"
     >
       <span id={id}>{children} </span>
-      {(hovered || copied || focused) && (
+      {(hovered || copied || focused) && !disableTooltip && (
         <span
           className={style.copyTooltip}
           aria-hidden

--- a/components/title-section/etablissement/index.tsx
+++ b/components/title-section/etablissement/index.tsx
@@ -4,6 +4,7 @@ import { Tag } from '#components-ui/tag';
 import IsActiveTag from '#components-ui/tag/is-active-tag';
 import { NonDiffusibleTag } from '#components-ui/tag/non-diffusible-tag';
 import { EtablissementDescription } from '#components/etablissement-description';
+import { CopyPaste } from '#components/table/copy-paste';
 import { ISession } from '#models/authentication/user/session';
 import { estNonDiffusibleStrict } from '#models/core/diffusion';
 import { IEtablissement, IUniteLegale } from '#models/core/types';
@@ -59,7 +60,13 @@ const TitleEtablissementWithDenomination: React.FC<{
 
     <div className={styles.subTitle}>
       <span className={styles.sirenOrSiret}>
-        {formatSiret(etablissement.siret)}
+        <CopyPaste
+          shouldRemoveSpace={true}
+          disableCopyIcon={true}
+          label="SIRET"
+        >
+          {formatSiret(etablissement.siret)}
+        </CopyPaste>
       </span>
       <NonDiffusibleTag etablissementOrUniteLegale={etablissement} />
       <IsActiveTag

--- a/components/title-section/index.tsx
+++ b/components/title-section/index.tsx
@@ -50,7 +50,7 @@ const Title: React.FC<IProps> = ({
           <span style={{ display: 'inline-flex' }}>
             <CopyPaste
               shouldRemoveSpace={true}
-              disableTooltip={true}
+              disableCopyIcon={true}
               label="SIREN"
             >
               {formatIntFr(uniteLegale.siren)}

--- a/components/title-section/index.tsx
+++ b/components/title-section/index.tsx
@@ -2,6 +2,7 @@ import SocialMedia from '#components-ui/social-media';
 import IsActiveTag from '#components-ui/tag/is-active-tag';
 import { NonDiffusibleTag } from '#components-ui/tag/non-diffusible-tag';
 import { SaveFavourite } from '#components/save-favourite';
+import { CopyPaste } from '#components/table/copy-paste';
 import UniteLegaleBadge from '#components/unite-legale-badge';
 import { UniteLegaleDescription } from '#components/unite-legale-description';
 import { UniteLegaleEtablissementCountDescription } from '#components/unite-legale-description/etablissement-count-description';
@@ -45,7 +46,16 @@ const Title: React.FC<IProps> = ({
       <div className={styles.subTitle}>
         <UniteLegaleBadge uniteLegale={uniteLegale} />
         <span className={styles.sirenTitle}>
-          &nbsp;‣&nbsp;{formatIntFr(uniteLegale.siren)}
+          &nbsp;‣&nbsp;
+          <span style={{ display: 'inline-flex' }}>
+            <CopyPaste
+              shouldRemoveSpace={true}
+              disableTooltip={true}
+              label="SIREN"
+            >
+              {formatIntFr(uniteLegale.siren)}
+            </CopyPaste>
+          </span>
         </span>
         <span>
           <NonDiffusibleTag etablissementOrUniteLegale={uniteLegale} />


### PR DESCRIPTION
- Amélioration technique.
- Détails :
  - Copier coller pour le siren en haut de la page
  - En copiant manuellement, on obtenait en plus des espaces

<img width="476" alt="image" src="https://github.com/user-attachments/assets/a435692e-74c5-4477-95a2-e2908a47ae6a" />

