### PR TITLE
feat: do not detect numeriqu.gouv.fr always as prestatiare

### DIFF
--- a/models/authentication/agent/agent-connected/index.test.ts
+++ b/models/authentication/agent/agent-connected/index.test.ts
@@ -51,6 +51,24 @@ describe('AgentConnected', () => {
       expect(agent.isLikelyPrestataire()).toBe(true);
     });
 
+    it('should not detect numerique.gouv.fr as prestataire', () => {
+      const prestataireUserInfo = {
+        ...mockUserInfo,
+        email: 'test@numerique.gouv.fr',
+      };
+      const agent = new AgentConnected(prestataireUserInfo);
+      expect(agent.isLikelyPrestataire()).toBe(false);
+    });
+
+    it('should detect numerique.gouv.fr with ext in name as prestataire', () => {
+      const prestataireUserInfo = {
+        ...mockUserInfo,
+        email: 'test.ext@numerique.gouv.fr',
+      };
+      const agent = new AgentConnected(prestataireUserInfo);
+      expect(agent.isLikelyPrestataire()).toBe(true);
+    });
+
     it('should detect prestataire by email pattern', () => {
       const prestataireUserInfo = {
         ...mockUserInfo,

--- a/models/authentication/agent/agent-connected/index.tsx
+++ b/models/authentication/agent/agent-connected/index.tsx
@@ -39,9 +39,7 @@ export class AgentConnected {
       'demarches-simplifiees.fr',
       'entreprise.api.gouv.fr',
       'franceconnect.gouv.fr',
-      'mail.numerique.gouv.fr',
       'monstagedetroisieme.fr',
-      'numerique.gouv.fr',
       'scn.rie.gouv.fr',
     ]) {
       if (this.domain.indexOf(bannedDomain) > -1) {


### PR DESCRIPTION
- Amélioration technique.
- Détails :
  - Email with numerique.gouv.fr are not always "prestaire"
