### PR TITLE
fix: log justice does not work if you shadow replace siret before

### DIFF
--- a/app/api/auth/agent-connect/callback/route.ts
+++ b/app/api/auth/agent-connect/callback/route.ts
@@ -25,9 +25,6 @@ export const GET = withSession(async function callbackRoute(req) {
     siretForException = userInfo.siret;
 
     if (!userInfo.siret) {
-      if (userInfo.idp_id === '9e139e69-de07-4cbe-987f-d12cb38c0368') {
-        userInfo.siret = '11001001400014';
-      }
       logWarningInSentry(
         new Information({
           name: 'NoSiretExceptionnalLogs',
@@ -36,6 +33,9 @@ export const GET = withSession(async function callbackRoute(req) {
           },
         })
       );
+      if (userInfo.idp_id === '9e139e69-de07-4cbe-987f-d12cb38c0368') {
+        userInfo.siret = '11001001400014';
+      }
     }
 
     const agent = new AgentConnected(userInfo);


### PR DESCRIPTION
As I modified userInfo.siret before the log, the log became useles... 🥲