### PR TITLE
feat: exclude @i-carre.net emails from l'espace agent

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,9 @@
 {
   "eslint.enable": true,
   "editor.formatOnSave": true,
-  "editor.codeActionsOnSave": ["source.organizeImports", "source.fixAll.eslint"]
+  "editor.codeActionsOnSave": [
+    "source.organizeImports",
+    "source.fixAll.eslint"
+  ],
+  "editor.tabSize": 2,
 }

--- a/models/user/agent.ts
+++ b/models/user/agent.ts
@@ -9,7 +9,8 @@ import { logWarningInSentry } from '#utils/sentry';
 
 const isLikelyPrestataire = (domain: string) => {
   try {
-    if (domain === '@beta.gouv.fr') {
+    const excludedDomains = ['@beta.gouv.fr', '@i-carre.net'];
+    if (excludedDomains.includes(domain)) {
       return true;
     } else {
       if (!!domain.match(/[.@-]*(ext)(ernal|ernes|erne)*[.@-]/g)) {


### PR DESCRIPTION
This domain is used by all external employees of the MTE.
