### PR TITLE
fix: idcc broken link

### DIFF
--- a/components/title-section/tabs/index.tsx
+++ b/components/title-section/tabs/index.tsx
@@ -112,7 +112,7 @@ export const Tabs: React.FC<{
     },
     {
       ficheType: FICHE.DIVERS,
-      path: '/divers/',
+      path: `/divers/${uniteLegale.siren}`,
       label: 'Conventions collectives',
       noFollow: false,
       shouldDisplay: (uniteLegale.listeIdcc || []).length > 0,


### PR DESCRIPTION
My bad I introduced a regression here https://github.com/annuaire-entreprises-data-gouv-fr/site/commit/74a3baed6ff5c6fb7078bd5cb691ae75127e822b

Interesting we have e2e tests on pages themselves but not on tabs @rmonnier9 