### PR TITLE
feat: hide temporary "Société à mission" filter

### DIFF
--- a/components/advanced-search/filter-structure.tsx
+++ b/components/advanced-search/filter-structure.tsx
@@ -87,25 +87,18 @@ export const FilterStructure: React.FC<{
           onClick={() => setLabelSelected('ess')}
         />
 
-        <LabelAndCertificateBadge
+        {/* <LabelAndCertificateBadge
           label="Société à mission"
           isSelected={labelSelected === 'sm'}
           small
           onClick={() => setLabelSelected('sm')}
-        />
+        /> */}
 
         <LabelAndCertificateBadge
           label="Entreprise Inclusive"
           isSelected={labelSelected === 'siae'}
           small
           onClick={() => setLabelSelected('siae')}
-        />
-
-        <LabelAndCertificateBadge
-          label="Achats Responsables"
-          isSelected={labelSelected === 'achats_responsables'}
-          small
-          onClick={() => setLabelSelected('achats_responsables')}
         />
 
         <LabelAndCertificateBadge
@@ -148,6 +141,13 @@ export const FilterStructure: React.FC<{
           isSelected={labelSelected === 'esv'}
           small
           onClick={() => setLabelSelected('esv')}
+        />
+
+        <LabelAndCertificateBadge
+          label="Achats Responsables"
+          isSelected={labelSelected === 'achats_responsables'}
+          small
+          onClick={() => setLabelSelected('achats_responsables')}
         />
       </div>
       <style jsx>{`

--- a/components/badges-section/labels-and-certificates/index.tsx
+++ b/components/badges-section/labels-and-certificates/index.tsx
@@ -79,14 +79,6 @@ export const LabelsAndCertificatesBadgesSection: React.FC<{
           siren={uniteLegale.siren}
         />
       )}
-      {estAchatsResponsables && (
-        <LabelWithLinkToSection
-          informationTooltipLabel="Ce label distingue les structures ayant fait la preuve de relations durables et équilibrées avec leurs fournisseurs."
-          label="Achats Responsables"
-          sectionId="achats-responsables"
-          siren={uniteLegale.siren}
-        />
-      )}
       {estOrganismeFormation &&
         (estQualiopi ? (
           <LabelWithLinkToSection
@@ -143,6 +135,14 @@ export const LabelsAndCertificatesBadgesSection: React.FC<{
             siren={uniteLegale.siren}
           />
         ))}
+      {estAchatsResponsables && (
+        <LabelWithLinkToSection
+          informationTooltipLabel="Ce label distingue les structures ayant fait la preuve de relations durables et équilibrées avec leurs fournisseurs."
+          label="Achats Responsables"
+          sectionId="achats-responsables"
+          siren={uniteLegale.siren}
+        />
+      )}
     </>
   );
 };

--- a/models/search/search-filter-params.ts
+++ b/models/search/search-filter-params.ts
@@ -223,12 +223,12 @@ class SearchFilterParams {
       qualiopi: 'Certifié : Qualiopi',
       sm: 'Qualité : Société à mission',
       siae: 'Qualité : Entreprise Inclusive',
-      achats_responsables: 'Label : Achats Responsables',
       of: 'Label : Organisme de formation',
       ei: 'Type : Entreprise Individuelle ',
       ct: 'Type : Collectivité territoriale ',
       sp: 'Type : Administration',
       asso: 'Type : Association ',
+      achats_responsables: 'Label : Achats Responsables',
     };
 
     if (this.params.type) {


### PR DESCRIPTION
- Amélioration technique.
- Détails :
  - Masquage du filtre société à mission jusqu'à ce qu'il soit de nouveau rendu opérationnel par l'INSEE
  - Filtre et section "Achats Responsables" sont placés en fin de liste (nouvelle fonctionnalité)

Closes #1740
