### PR TITLE
fix: alim confiance

### DIFF
--- a/app/(header-default)/dirigeants/[slug]/_component/sections/entreprise/alim-confiance/section.tsx
+++ b/app/(header-default)/dirigeants/[slug]/_component/sections/entreprise/alim-confiance/section.tsx
@@ -22,7 +22,7 @@ export default function AlimConfianceSection({ uniteLegale }: IProps) {
 
   return (
     <AsyncDataSectionClient
-      id="dpo-section"
+      id="alim-confiance"
       title="Dispositif d'information Alim’confiance"
       sources={[EAdministration.MAA]}
       isProtected={false}

--- a/app/(header-default)/dirigeants/[slug]/_component/sections/entreprise/alim-confiance/section.tsx
+++ b/app/(header-default)/dirigeants/[slug]/_component/sections/entreprise/alim-confiance/section.tsx
@@ -27,7 +27,12 @@ export default function AlimConfianceSection({ uniteLegale }: IProps) {
       sources={[EAdministration.MAA]}
       isProtected={false}
       data={alimConfiance}
-      notFoundInfo={null}
+      notFoundInfo={
+        <p>
+          Nous n’avons pas trouvé de résultat de contrôle sanitaire pour cette
+          structure.
+        </p>
+      }
     >
       {(alimConfiance) => {
         const plural = pluralize(alimConfiance);

--- a/app/(header-default)/labels-certificats/[slug]/page.tsx
+++ b/app/(header-default)/labels-certificats/[slug]/page.tsx
@@ -70,6 +70,7 @@ const LabelsAndCertificatsPage = async (props: AppRouterProps) => {
     estEntrepriseInclusive,
     estAchatsResponsables,
     estPatrimoineVivant,
+    estAlimConfiance,
   } = uniteLegale.complements;
 
   const {
@@ -132,7 +133,9 @@ const LabelsAndCertificatsPage = async (props: AppRouterProps) => {
         )}
         {estAchatsResponsables && <LabelAchatsResponsables />}
         {estPatrimoineVivant && <LabelPatrimoineVivant />}
-        <AlimConfianceSection uniteLegale={uniteLegale} session={session} />
+        {estAlimConfiance && (
+          <AlimConfianceSection uniteLegale={uniteLegale} session={session} />
+        )}
       </div>
     </>
   );

--- a/clients/recherche-entreprise/index.ts
+++ b/clients/recherche-entreprise/index.ts
@@ -178,6 +178,7 @@ const mapToUniteLegale = (result: IResult, pageEtablissements: number) => {
     type_siae = '',
     est_achats_responsables = false,
     est_patrimoine_vivant = false,
+    est_alim_confiance = false,
   } = complements || {};
 
   const nomComplet = (result.nom_complet || 'Nom inconnu').toUpperCase();
@@ -268,6 +269,7 @@ const mapToUniteLegale = (result: IResult, pageEtablissements: number) => {
       estEntrepriseInclusive: est_siae,
       typeEntrepriseInclusive: type_siae,
       estPatrimoineVivant: est_patrimoine_vivant,
+      estAlimConfiance: est_alim_confiance,
     },
     immatriculation: mapToImmatriculation(immatriculation),
     association: {

--- a/clients/recherche-entreprise/interface.ts
+++ b/clients/recherche-entreprise/interface.ts
@@ -124,6 +124,7 @@ export type IComplements = {
   type_siae: string;
   est_achats_responsables: boolean;
   est_patrimoine_vivant: boolean;
+  est_alim_confiance: boolean;
   liste_idcc: string[];
 };
 

--- a/components/badges-section/labels-and-certificates/index.tsx
+++ b/components/badges-section/labels-and-certificates/index.tsx
@@ -21,6 +21,7 @@ export const labelsAndCertificatesSources = (uniteLegale: IUniteLegale) => {
     estEntrepriseInclusive,
     estAchatsResponsables,
     estPatrimoineVivant,
+    estAlimConfiance,
   } = uniteLegale.complements;
   if (estEntrepreneurSpectacle) sources.push(EAdministration.MC);
   if (estEss || estSocieteMission) sources.push(EAdministration.INSEE);
@@ -31,6 +32,7 @@ export const labelsAndCertificatesSources = (uniteLegale: IUniteLegale) => {
   if (estEntrepriseInclusive) sources.push(EAdministration.MARCHE_INCLUSION);
   if (estAchatsResponsables) sources.push(EAdministration.MEF);
   if (estPatrimoineVivant) sources.push(EAdministration.MEF);
+  if (estAlimConfiance) sources.push(EAdministration.MAA);
   return sources;
 };
 
@@ -54,6 +56,7 @@ export const LabelsAndCertificatesBadgesSection: React.FC<{
     typeEntrepriseInclusive,
     estAchatsResponsables,
     estPatrimoineVivant,
+    estAlimConfiance,
   } = uniteLegale.complements;
 
   return (
@@ -150,6 +153,14 @@ export const LabelsAndCertificatesBadgesSection: React.FC<{
         <LabelWithLinkToSection
           informationTooltipLabel="Cette structure est labelisée Entreprise du Patrimoine Vivant"
           label="Entreprise du Patrimoine Vivant"
+          sectionId="patrimoine-vivant"
+          siren={uniteLegale.siren}
+        />
+      )}
+      {estAlimConfiance && (
+        <LabelWithLinkToSection
+          informationTooltipLabel="Cette structure dispose de résultats de contrôles sanitaires (Alim'Confiance)"
+          label="Alim'Confiance"
           sectionId="patrimoine-vivant"
           siren={uniteLegale.siren}
         />

--- a/components/badges-section/labels-and-certificates/index.tsx
+++ b/components/badges-section/labels-and-certificates/index.tsx
@@ -161,7 +161,7 @@ export const LabelsAndCertificatesBadgesSection: React.FC<{
         <LabelWithLinkToSection
           informationTooltipLabel="Cette structure dispose de résultats de contrôles sanitaires (Alim'Confiance)"
           label="Alim'Confiance"
-          sectionId="patrimoine-vivant"
+          sectionId="alim-confiance"
           siren={uniteLegale.siren}
         />
       )}

--- a/models/core/types.ts
+++ b/models/core/types.ts
@@ -195,6 +195,7 @@ export interface IUniteLegaleComplements {
   typeEntrepriseInclusive: string;
   estAchatsResponsables: boolean;
   estPatrimoineVivant: boolean;
+  estAlimConfiance: boolean;
   estUai: boolean;
 }
 
@@ -220,6 +221,7 @@ export const createDefaultUniteLegaleComplements =
       typeEntrepriseInclusive: '',
       estAchatsResponsables: false,
       estPatrimoineVivant: false,
+      estAlimConfiance: false,
     };
   };
 


### PR DESCRIPTION
- Changement mineur.
- Détails :
  - Utilisation du champ est_alim_confiance

Question : Peut-être devrions-nous préciser la notion de labels et certificats ?
Alim'Confiance n'est ni l'un ni l'autre, juste un dispositif qui met en open data les résultats de contrôle sanitaire


<img width="1292" alt="image" src="https://github.com/user-attachments/assets/6009b9d2-6bd5-42d3-9d35-089664e8652c" />

<img width="1351" alt="image" src="https://github.com/user-attachments/assets/f7043dc5-d175-43f8-b9a6-c3ac553d0a91" />

