### PR TITLE
feat: pagination alim confiance

### DIFF
--- a/app/(header-default)/dirigeants/[slug]/_component/sections/entreprise/alim-confiance/section.tsx
+++ b/app/(header-default)/dirigeants/[slug]/_component/sections/entreprise/alim-confiance/section.tsx
@@ -49,12 +49,14 @@ export default function AlimConfianceSection({ uniteLegale }: IProps) {
                 {plural} ayant fait l‘objet d‘un contrôle sanitaire :
               </p>
 
-              <LocalPageCounter
-                currentPage={currentPage}
-                totalPages={Math.ceil(total / page_size)}
-                onPageChange={setCurrentPage}
-                compact={true}
-              />
+              {total > 20 && (
+                <LocalPageCounter
+                  currentPage={currentPage}
+                  totalPages={Math.ceil(total / page_size)}
+                  onPageChange={setCurrentPage}
+                  compact={true}
+                />
+              )}
 
               <FullTable
                 head={[

--- a/app/(header-default)/dirigeants/[slug]/_component/sections/entreprise/alim-confiance/section.tsx
+++ b/app/(header-default)/dirigeants/[slug]/_component/sections/entreprise/alim-confiance/section.tsx
@@ -97,6 +97,8 @@ export default function AlimConfianceSection({ uniteLegale }: IProps) {
                           ? 'error'
                           : code === '3'
                           ? 'warning'
+                          : code === '2'
+                          ? 'info'
                           : 'success'
                       }
                     >

--- a/app/(header-default)/dirigeants/[slug]/_component/sections/entreprise/alim-confiance/section.tsx
+++ b/app/(header-default)/dirigeants/[slug]/_component/sections/entreprise/alim-confiance/section.tsx
@@ -1,13 +1,15 @@
 'use client';
 
 import { Tag } from '#components-ui/tag';
+import LocalPageCounter from '#components/search-results/results-pagination/local-pagination';
 import { AsyncDataSectionClient } from '#components/section/data-section/client';
 import { FullTable } from '#components/table/full';
 import { EAdministration } from '#models/administrations/EAdministration';
 import { ISession } from '#models/authentication/user/session';
 import { IUniteLegale } from '#models/core/types';
-import { formatDate, formatSiret, pluralize } from '#utils/helpers';
+import { formatDate, formatSiret } from '#utils/helpers';
 import { useFetchAlimConfiance } from 'hooks/fetch/alim-confiance';
+import { useState } from 'react';
 
 type IProps = {
   uniteLegale: IUniteLegale;
@@ -15,15 +17,16 @@ type IProps = {
 };
 
 /**
- * Alim‘Confiance section
+ * Alim'Confiance section
  */
 export default function AlimConfianceSection({ uniteLegale }: IProps) {
-  const alimConfiance = useFetchAlimConfiance(uniteLegale);
+  const [currentPage, setCurrentPage] = useState(1);
+  const alimConfiance = useFetchAlimConfiance(uniteLegale, currentPage);
 
   return (
     <AsyncDataSectionClient
       id="alim-confiance"
-      title="Dispositif d'information Alim’confiance"
+      title="Dispositif d‘information Alim‘confiance"
       sources={[EAdministration.MAA]}
       isProtected={false}
       data={alimConfiance}
@@ -35,15 +38,23 @@ export default function AlimConfianceSection({ uniteLegale }: IProps) {
       }
     >
       {(alimConfiance) => {
-        const plural = pluralize(alimConfiance);
+        const { total, page_size } = alimConfiance.meta;
+        const plural = total > 1 ? 's' : '';
 
         return (
           <>
             <div>
               <p>
-                Cette structure possède {alimConfiance.length} établissement
+                Cette structure possède {total} établissement
                 {plural} ayant fait l‘objet d‘un contrôle sanitaire :
               </p>
+
+              <LocalPageCounter
+                currentPage={currentPage}
+                totalPages={Math.ceil(total / page_size)}
+                onPageChange={setCurrentPage}
+                compact={true}
+              />
 
               <FullTable
                 head={[
@@ -53,7 +64,7 @@ export default function AlimConfianceSection({ uniteLegale }: IProps) {
                   "Type d'activité",
                 ]}
                 columnWidths={['40%', '20%', '25%', '15%']}
-                body={alimConfiance.map(
+                body={alimConfiance.data.map(
                   ({
                     siret,
                     denomination,

--- a/clients/api-data-gouv/alim-confiance/index.ts
+++ b/clients/api-data-gouv/alim-confiance/index.ts
@@ -9,7 +9,7 @@ export const clientAlimConfiance = async (
   page: number = 1
 ): Promise<IAlimConfiance> => {
   const response = await httpGet<IAlimConfianceDatagouvResponse>(
-    `${routes.datagouv.alimConfiance}?SIRET__greater=${siren}00000&SIRET__less=${siren}99999&page=${page}&page_size=20`,
+    `${routes.datagouv.alimConfiance}?SIRET__sort=asc&SIRET__greater=${siren}00000&SIRET__less=${siren}99999&page=${page}&page_size=20`,
     {
       timeout: constants.timeout.S,
     }

--- a/clients/api-data-gouv/alim-confiance/index.ts
+++ b/clients/api-data-gouv/alim-confiance/index.ts
@@ -5,10 +5,11 @@ import { Siren } from '#utils/helpers';
 import { httpGet } from '#utils/network';
 
 export const clientAlimConfiance = async (
-  siren: Siren
-): Promise<IAlimConfiance[]> => {
+  siren: Siren,
+  page: number = 1
+): Promise<IAlimConfiance> => {
   const response = await httpGet<IAlimConfianceDatagouvResponse>(
-    `${routes.datagouv.alimConfiance}?SIRET__greater=${siren}00000&SIRET__less=${siren}99999`,
+    `${routes.datagouv.alimConfiance}?SIRET__greater=${siren}00000&SIRET__less=${siren}99999&page=${page}&page_size=20`,
     {
       timeout: constants.timeout.S,
     }
@@ -18,19 +19,24 @@ export const clientAlimConfiance = async (
     throw new HttpNotFound(`No Alim Confiance record found for siren ${siren}`);
   }
 
-  return mapToDomainObject(response.data);
+  return mapToDomainObject(response);
 };
 
-const mapToDomainObject = (response: IAlimConfianceItem[]) => {
-  return response.map((item) => ({
-    syntheseEvaluation: item['Synthese_eval_sanit'],
-    dateInspection: item['Date_inspection'],
-    libelleActiviteEtablissement: item['APP_Libelle_activite_etablissement'],
-    siret: item['SIRET'],
-    denomination: item['APP_Libelle_etablissement'],
-    adresse: item['Adresse_2_UA'],
-    codePostal: item['com_code'],
-    commune: item['com_name'],
-    code: item['APP_Code_synthese_eval_sanit'],
-  }));
+const mapToDomainObject = (
+  response: IAlimConfianceDatagouvResponse
+): IAlimConfiance => {
+  return {
+    data: response.data.map((item) => ({
+      syntheseEvaluation: item['Synthese_eval_sanit'],
+      dateInspection: item['Date_inspection'],
+      libelleActiviteEtablissement: item['APP_Libelle_activite_etablissement'],
+      siret: item['SIRET'],
+      denomination: item['APP_Libelle_etablissement'],
+      adresse: item['Adresse_2_UA'],
+      codePostal: item['com_code'],
+      commune: item['com_name'],
+      code: item['APP_Code_synthese_eval_sanit'],
+    })),
+    meta: response.meta,
+  };
 };

--- a/clients/api-data-gouv/alim-confiance/interface.ts
+++ b/clients/api-data-gouv/alim-confiance/interface.ts
@@ -1,4 +1,4 @@
-type IAlimConfianceItem = {
+type IAlimConfianceDatagouvItem = {
   __id: string;
   APP_Libelle_etablissement: string;
   SIRET: string;
@@ -22,7 +22,7 @@ type IAlimConfianceItem = {
 };
 
 type IAlimConfianceDatagouvResponse = {
-  data: IAlimConfianceItem[];
+  data: IAlimConfianceDatagouvItem[];
   links: {
     profile: string;
     swagger: string;
@@ -36,7 +36,7 @@ type IAlimConfianceDatagouvResponse = {
   };
 };
 
-type IAlimConfiance = {
+type IAlimConfianceItem = {
   syntheseEvaluation: string;
   dateInspection: string;
   libelleActiviteEtablissement: string;
@@ -46,4 +46,13 @@ type IAlimConfiance = {
   codePostal: string;
   commune: string;
   code: string;
+};
+
+type IAlimConfiance = {
+  data: IAlimConfianceItem[];
+  meta: {
+    page: number;
+    page_size: number;
+    total: number;
+  };
 };

--- a/clients/recherche-entreprise/index.ts
+++ b/clients/recherche-entreprise/index.ts
@@ -178,7 +178,7 @@ const mapToUniteLegale = (result: IResult, pageEtablissements: number) => {
     type_siae = '',
     est_achats_responsables = false,
     est_patrimoine_vivant = false,
-    est_alim_confiance = true,
+    est_alim_confiance = false,
   } = complements || {};
 
   const nomComplet = (result.nom_complet || 'Nom inconnu').toUpperCase();

--- a/clients/recherche-entreprise/index.ts
+++ b/clients/recherche-entreprise/index.ts
@@ -178,7 +178,7 @@ const mapToUniteLegale = (result: IResult, pageEtablissements: number) => {
     type_siae = '',
     est_achats_responsables = false,
     est_patrimoine_vivant = false,
-    est_alim_confiance = false,
+    est_alim_confiance = true,
   } = complements || {};
 
   const nomComplet = (result.nom_complet || 'Nom inconnu').toUpperCase();

--- a/components/search-results/results-pagination/index.tsx
+++ b/components/search-results/results-pagination/index.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { buildSearchQuery, IParams } from '#models/search/search-filter-params';
+import React from 'react';
 import pagesArray from './pages-array';
 
 type IProps = {
@@ -146,7 +146,7 @@ const Page: React.FC<{
  * @param param0
  * @returns
  */
-const ResultsPagination: React.FC<IProps> = ({
+const PageCounter: React.FC<IProps> = ({
   currentPage,
   searchTerm,
   totalPages,
@@ -213,4 +213,4 @@ const ResultsPagination: React.FC<IProps> = ({
   );
 };
 
-export default ResultsPagination;
+export default PageCounter;

--- a/components/search-results/results-pagination/local-pagination.tsx
+++ b/components/search-results/results-pagination/local-pagination.tsx
@@ -1,143 +1,85 @@
 import React from 'react';
-import { buildSearchQuery, IParams } from '#models/search/search-filter-params';
 import pagesArray from './pages-array';
 
 type IProps = {
   currentPage: number;
   totalPages: number;
   compact?: boolean;
-  searchTerm?: string;
-  searchFilterParams?: IParams;
-  urlComplement?: string;
+  onPageChange: (page: number) => void;
 };
 
-const urlParams = (
-  page = 1,
-  searchTerm = '',
-  searchfilterParams?: IParams,
-  urlComplement = ''
-) => {
-  const searchQuery = buildSearchQuery(searchTerm, searchfilterParams || {});
-  return `${searchQuery}&page=${page}${urlComplement}`;
-};
-
-const First: React.FC<IProps> = ({
-  searchTerm,
-  currentPage,
-  compact,
-  searchFilterParams,
-  urlComplement,
-}) => (
+const First: React.FC<IProps> = ({ currentPage, compact, onPageChange }) => (
   <li>
-    <a
+    <button
       className="fr-pagination__link fr-pagination__link--first fr-pagination__link--lg-label"
-      href={
-        currentPage > 1
-          ? urlParams(1, searchTerm, searchFilterParams, urlComplement)
-          : undefined
-      }
+      onClick={() => currentPage > 1 && onPageChange(1)}
+      disabled={currentPage <= 1}
     >
       {compact ? '' : 'Première page'}
-    </a>
+    </button>
   </li>
 );
 
 const Last: React.FC<IProps> = ({
   currentPage,
-  searchTerm,
   totalPages,
   compact,
-  searchFilterParams,
-  urlComplement,
+  onPageChange,
 }) => (
   <li>
-    <a
+    <button
       className="fr-pagination__link fr-pagination__link--last"
-      href={
-        currentPage < totalPages
-          ? urlParams(totalPages, searchTerm, searchFilterParams, urlComplement)
-          : undefined
-      }
+      onClick={() => currentPage < totalPages && onPageChange(totalPages)}
+      disabled={currentPage >= totalPages}
     >
       {compact ? '' : 'Dernière page'}
-    </a>
+    </button>
   </li>
 );
-const Previous: React.FC<IProps> = ({
-  currentPage,
-  searchTerm,
-  searchFilterParams,
-  compact,
-  urlComplement,
-}) => (
+
+const Previous: React.FC<IProps> = ({ currentPage, compact, onPageChange }) => (
   <li>
-    <a
+    <button
       className="fr-pagination__link fr-pagination__link--prev fr-pagination__link--lg-label"
-      href={
-        currentPage > 1
-          ? urlParams(
-              currentPage - 1,
-              searchTerm,
-              searchFilterParams,
-              urlComplement
-            )
-          : undefined
-      }
+      onClick={() => currentPage > 1 && onPageChange(currentPage - 1)}
+      disabled={currentPage <= 1}
     >
       {compact ? '' : 'Page précédente'}
-    </a>
+    </button>
   </li>
 );
 
 const Next: React.FC<IProps> = ({
   currentPage,
-  searchTerm,
   totalPages,
-  searchFilterParams,
   compact,
-  urlComplement,
+  onPageChange,
 }) => (
   <li>
-    <a
+    <button
       className="fr-pagination__link fr-pagination__link--next fr-pagination__link--lg-label"
-      href={
-        currentPage < totalPages
-          ? urlParams(
-              currentPage + 1,
-              searchTerm,
-              searchFilterParams,
-              urlComplement
-            )
-          : undefined
-      }
+      onClick={() => currentPage < totalPages && onPageChange(currentPage + 1)}
+      disabled={currentPage >= totalPages}
     >
       {compact ? '' : 'Page suivante'}
-    </a>
+    </button>
   </li>
 );
 
 const Page: React.FC<{
   pageNum: number;
-  searchTerm?: string;
   currentPage: number;
-  searchFilterParams?: IParams;
-  urlComplement?: string;
-}> = ({
-  pageNum,
-  searchTerm,
-  currentPage,
-  searchFilterParams,
-  urlComplement,
-}) => (
+  onPageChange: (page: number) => void;
+}> = ({ pageNum, currentPage, onPageChange }) => (
   <li>
-    <a
-      href={urlParams(pageNum, searchTerm, searchFilterParams, urlComplement)}
-      className="fr-pagination__link "
+    <button
+      onClick={() => onPageChange(pageNum)}
+      className="fr-pagination__link"
       aria-current={currentPage === pageNum ? 'page' : undefined}
       title={`Page ${pageNum}`}
     >
       {pageNum}
-    </a>
+    </button>
   </li>
 );
 
@@ -146,12 +88,10 @@ const Page: React.FC<{
  * @param param0
  * @returns
  */
-const ResultsPagination: React.FC<IProps> = ({
+const LocalPageCounter: React.FC<IProps> = ({
   currentPage,
-  searchTerm,
   totalPages,
-  searchFilterParams,
-  urlComplement = '',
+  onPageChange,
   compact = false,
 }) => {
   const pages = pagesArray(currentPage, totalPages);
@@ -165,47 +105,37 @@ const ResultsPagination: React.FC<IProps> = ({
         <ul className="fr-pagination__list">
           <First
             currentPage={currentPage}
-            searchTerm={searchTerm}
             totalPages={totalPages}
             compact={compact}
-            searchFilterParams={searchFilterParams}
-            urlComplement={urlComplement}
+            onPageChange={onPageChange}
           />
           <Previous
             currentPage={currentPage}
-            searchTerm={searchTerm}
             totalPages={totalPages}
             compact={compact}
-            searchFilterParams={searchFilterParams}
-            urlComplement={urlComplement}
+            onPageChange={onPageChange}
           />
           {pages.map((pageNum) => {
             return (
               <Page
-                searchFilterParams={searchFilterParams}
                 currentPage={currentPage}
-                searchTerm={searchTerm}
                 pageNum={pageNum}
-                urlComplement={urlComplement}
+                onPageChange={onPageChange}
                 key={pageNum}
               />
             );
           })}
           <Next
             currentPage={currentPage}
-            searchTerm={searchTerm}
             compact={compact}
             totalPages={totalPages}
-            searchFilterParams={searchFilterParams}
-            urlComplement={urlComplement}
+            onPageChange={onPageChange}
           />
           <Last
             currentPage={currentPage}
             compact={compact}
-            searchTerm={searchTerm}
             totalPages={totalPages}
-            searchFilterParams={searchFilterParams}
-            urlComplement={urlComplement}
+            onPageChange={onPageChange}
           />
         </ul>
       </nav>
@@ -213,4 +143,4 @@ const ResultsPagination: React.FC<IProps> = ({
   );
 };
 
-export default ResultsPagination;
+export default LocalPageCounter;

--- a/components/search-results/results-pagination/local-pagination.tsx
+++ b/components/search-results/results-pagination/local-pagination.tsx
@@ -1,0 +1,216 @@
+import React from 'react';
+import { buildSearchQuery, IParams } from '#models/search/search-filter-params';
+import pagesArray from './pages-array';
+
+type IProps = {
+  currentPage: number;
+  totalPages: number;
+  compact?: boolean;
+  searchTerm?: string;
+  searchFilterParams?: IParams;
+  urlComplement?: string;
+};
+
+const urlParams = (
+  page = 1,
+  searchTerm = '',
+  searchfilterParams?: IParams,
+  urlComplement = ''
+) => {
+  const searchQuery = buildSearchQuery(searchTerm, searchfilterParams || {});
+  return `${searchQuery}&page=${page}${urlComplement}`;
+};
+
+const First: React.FC<IProps> = ({
+  searchTerm,
+  currentPage,
+  compact,
+  searchFilterParams,
+  urlComplement,
+}) => (
+  <li>
+    <a
+      className="fr-pagination__link fr-pagination__link--first fr-pagination__link--lg-label"
+      href={
+        currentPage > 1
+          ? urlParams(1, searchTerm, searchFilterParams, urlComplement)
+          : undefined
+      }
+    >
+      {compact ? '' : 'Première page'}
+    </a>
+  </li>
+);
+
+const Last: React.FC<IProps> = ({
+  currentPage,
+  searchTerm,
+  totalPages,
+  compact,
+  searchFilterParams,
+  urlComplement,
+}) => (
+  <li>
+    <a
+      className="fr-pagination__link fr-pagination__link--last"
+      href={
+        currentPage < totalPages
+          ? urlParams(totalPages, searchTerm, searchFilterParams, urlComplement)
+          : undefined
+      }
+    >
+      {compact ? '' : 'Dernière page'}
+    </a>
+  </li>
+);
+const Previous: React.FC<IProps> = ({
+  currentPage,
+  searchTerm,
+  searchFilterParams,
+  compact,
+  urlComplement,
+}) => (
+  <li>
+    <a
+      className="fr-pagination__link fr-pagination__link--prev fr-pagination__link--lg-label"
+      href={
+        currentPage > 1
+          ? urlParams(
+              currentPage - 1,
+              searchTerm,
+              searchFilterParams,
+              urlComplement
+            )
+          : undefined
+      }
+    >
+      {compact ? '' : 'Page précédente'}
+    </a>
+  </li>
+);
+
+const Next: React.FC<IProps> = ({
+  currentPage,
+  searchTerm,
+  totalPages,
+  searchFilterParams,
+  compact,
+  urlComplement,
+}) => (
+  <li>
+    <a
+      className="fr-pagination__link fr-pagination__link--next fr-pagination__link--lg-label"
+      href={
+        currentPage < totalPages
+          ? urlParams(
+              currentPage + 1,
+              searchTerm,
+              searchFilterParams,
+              urlComplement
+            )
+          : undefined
+      }
+    >
+      {compact ? '' : 'Page suivante'}
+    </a>
+  </li>
+);
+
+const Page: React.FC<{
+  pageNum: number;
+  searchTerm?: string;
+  currentPage: number;
+  searchFilterParams?: IParams;
+  urlComplement?: string;
+}> = ({
+  pageNum,
+  searchTerm,
+  currentPage,
+  searchFilterParams,
+  urlComplement,
+}) => (
+  <li>
+    <a
+      href={urlParams(pageNum, searchTerm, searchFilterParams, urlComplement)}
+      className="fr-pagination__link "
+      aria-current={currentPage === pageNum ? 'page' : undefined}
+      title={`Page ${pageNum}`}
+    >
+      {pageNum}
+    </a>
+  </li>
+);
+
+/**
+ * Page counter component. Be careful as it is not zero-indexed. Pages starts at 1
+ * @param param0
+ * @returns
+ */
+const ResultsPagination: React.FC<IProps> = ({
+  currentPage,
+  searchTerm,
+  totalPages,
+  searchFilterParams,
+  urlComplement = '',
+  compact = false,
+}) => {
+  const pages = pagesArray(currentPage, totalPages);
+  if (pages.length === 1) {
+    return null;
+  }
+
+  return (
+    <div className="layout-center" style={{ margin: '15px auto' }}>
+      <nav role="navigation" className="fr-pagination" aria-label="Pagination">
+        <ul className="fr-pagination__list">
+          <First
+            currentPage={currentPage}
+            searchTerm={searchTerm}
+            totalPages={totalPages}
+            compact={compact}
+            searchFilterParams={searchFilterParams}
+            urlComplement={urlComplement}
+          />
+          <Previous
+            currentPage={currentPage}
+            searchTerm={searchTerm}
+            totalPages={totalPages}
+            compact={compact}
+            searchFilterParams={searchFilterParams}
+            urlComplement={urlComplement}
+          />
+          {pages.map((pageNum) => {
+            return (
+              <Page
+                searchFilterParams={searchFilterParams}
+                currentPage={currentPage}
+                searchTerm={searchTerm}
+                pageNum={pageNum}
+                urlComplement={urlComplement}
+                key={pageNum}
+              />
+            );
+          })}
+          <Next
+            currentPage={currentPage}
+            searchTerm={searchTerm}
+            compact={compact}
+            totalPages={totalPages}
+            searchFilterParams={searchFilterParams}
+            urlComplement={urlComplement}
+          />
+          <Last
+            currentPage={currentPage}
+            compact={compact}
+            searchTerm={searchTerm}
+            totalPages={totalPages}
+            searchFilterParams={searchFilterParams}
+            urlComplement={urlComplement}
+          />
+        </ul>
+      </nav>
+    </div>
+  );
+};
+
+export default ResultsPagination;

--- a/hooks/fetch/alim-confiance.ts
+++ b/hooks/fetch/alim-confiance.ts
@@ -6,10 +6,14 @@ import { verifySiren } from '#utils/helpers';
 import logErrorInSentry from '#utils/sentry';
 import { useFetchExternalData } from './use-fetch-data';
 
-export function useFetchAlimConfiance(uniteLegale: IUniteLegale) {
+export function useFetchAlimConfiance(
+  uniteLegale: IUniteLegale,
+  page: number = 1
+) {
   return useFetchExternalData(
     {
-      fetchData: () => clientAlimConfiance(verifySiren(uniteLegale.siren)),
+      fetchData: () =>
+        clientAlimConfiance(verifySiren(uniteLegale.siren), page),
       administration: EAdministration.MAA,
       logError: (e: any) => {
         if (e.status === 404) {
@@ -26,6 +30,6 @@ export function useFetchAlimConfiance(uniteLegale: IUniteLegale) {
         logErrorInSentry(exception);
       },
     },
-    [uniteLegale]
+    [uniteLegale, page]
   );
 }


### PR DESCRIPTION
- Correction d'un bug.
- Détails :
  - Ajout d'une pagination pour alim'confiance
  - Création d'un composant de pagination avec state local

Note UX : la pagination est en haut pour éviter les sauts lorsque l'on pagine (si la hauteur de la table est différente)

(cette PR contient les changements en double de l'autre PR Alim'Confiance, il vaut mieux d'abord merge https://github.com/annuaire-entreprises-data-gouv-fr/site/pull/1758)

<img width="1326" alt="image" src="https://github.com/user-attachments/assets/57bd1eda-b91d-4329-ae4d-84f37b80e815" />


