### PR TITLE
[Grist]chore: udpate grist docId

### DIFF
--- a/clients/external-tooling/grist.ts
+++ b/clients/external-tooling/grist.ts
@@ -12,15 +12,15 @@ type IGristRecords = {
 
 const gristTables = {
   'nps-feedbacks': {
-    docId: 'hp8PLhMGY9sNWuzGDGe6yi',
+    docId: 'uE2WGSjyBbSfiuSGbQiN9K',
     tableId: 'NPS_Feedbacks',
   },
   'hide-personal-data': {
-    docId: 'hp8PLhMGY9sNWuzGDGe6yi',
+    docId: 'uE2WGSjyBbSfiuSGbQiN9K',
     tableId: 'Hide_personal_data_requests',
   },
   'protected-siren': {
-    docId: 'hp8PLhMGY9sNWuzGDGe6yi',
+    docId: 'uE2WGSjyBbSfiuSGbQiN9K',
     tableId: 'Protected_siren',
   },
 } as const;


### PR DESCRIPTION
depends on https://github.com/annuaire-entreprises-data-gouv-fr/infrastructure/pull/427
closes https://github.com/annuaire-entreprises-data-gouv-fr/site/issues/1689

@rmonnier9 I'm leaving the PR testing in your hands. The tables might be updated before you're back, so please double-check that they are identical before merging.

For reference:

* Old document: https://grist.numerique.gouv.fr/o/docs/hp8PLhMGY9sN/Annuaire-des-Entreprises
* New document: https://grist.numerique.gouv.fr/o/datagouv/uE2WGSjyBbSf/Site

The tableId are the same since I didn't change the table names.

I've also updated the API token in Ansible to use mine.

@XavierJp fyi
