### PR TITLE
feat: redirect search from map to list when no results

### DIFF
--- a/components/search-results/map/index.tsx
+++ b/components/search-results/map/index.tsx
@@ -1,11 +1,10 @@
 import MapWithResults from '#components/map/map-results';
 import { ISearchResults } from '#models/search';
-import { IParams } from '#models/search/search-filter-params';
+import { buildSearchQuery, IParams } from '#models/search/search-filter-params';
+import { redirect } from 'next/navigation';
 import ResultsCounter from '../results-counter';
 import ResultsList from '../results-list';
 import ResultsPagination from '../results-pagination';
-import { BadParams } from '../results-problems/bad-params';
-import { NotEnoughParams } from '../results-problems/results-not-enough-params';
 import styles from './style.module.css';
 
 const SearchResultsMap: React.FC<{
@@ -15,51 +14,13 @@ const SearchResultsMap: React.FC<{
 }> = ({ results, searchTerm = '', searchFilterParams = {} }) => {
   const height = 'calc(100vh - 230px)';
 
-  if (searchTerm && results.notEnoughParams) {
-    return (
-      <div className="fr-container">
-        <NotEnoughParams />
-      </div>
-    );
-  }
-  if (results.notEnoughParams) {
-    return (
-      <MapWithResults
-        results={results}
-        height={height}
-        shouldColorZipCode={false}
-      />
-    );
-  }
-  if (results.badParams) {
-    return (
-      <div className="fr-container">
-        <BadParams />
-      </div>
-    );
-  }
-
-  if (!results.results || results.results.length === 0) {
-    return (
-      <>
-        <div className={styles['map-container']} style={{ height: height }}>
-          <MapWithResults
-            results={results}
-            height={height}
-            shouldColorZipCode={false}
-          />
-          <div className={styles['results-for-map-wrapper']}>
-            <ResultsCounter
-              resultCount={results.resultCount}
-              currentPage={results.currentPage}
-              isMap={true}
-              currentSearchTerm={searchTerm}
-              searchParams={searchFilterParams}
-            />
-          </div>
-        </div>
-      </>
-    );
+  if (
+    results.notEnoughParams ||
+    results.badParams ||
+    !results.results ||
+    results.results.length === 0
+  ) {
+    redirect(`/rechercher/${buildSearchQuery(searchTerm, searchFilterParams)}`);
   }
   const shouldColorZipCode = !!searchFilterParams.cp_dep;
 


### PR DESCRIPTION
- Changement mineur.
- Détails :
  - Redirection de la recherche vers le format liste quand il n'y a pas de résultat
  - Par défaut, toute recherche est donc sous format liste avec ensuite possibilité de l'afficher sous format carte

1. On ne montre plus une carte vide
2. Cela résout le fait que le toggle map/list n'est plus accessible quand il n'y a pas de résultat

@renardpal 

Problème - Carte vide et pas de toggle accessible
<img width="1470" alt="image" src="https://github.com/user-attachments/assets/52ae84d7-f624-4eb5-bb78-26c6bdcd58dc" />


Closes #1783

