### PR TITLE
feat: consultant email are prestataire

### DIFF
--- a/models/authentication/agent/agent-connected/index.test.ts
+++ b/models/authentication/agent/agent-connected/index.test.ts
@@ -103,6 +103,15 @@ describe('AgentConnected', () => {
       expect(agent.isLikelyPrestataire()).toBe(true);
     });
 
+    it('should detect prestataire by email pattern', () => {
+      const prestataireUserInfo = {
+        ...mockUserInfo,
+        email: 'prenom.nom-consultant@example.com',
+      };
+      const agent = new AgentConnected(prestataireUserInfo);
+      expect(agent.isLikelyPrestataire()).toBe(true);
+    });
+
     it('should not detect regular user as prestataire', () => {
       const agent = new AgentConnected(mockUserInfo);
       expect(agent.isLikelyPrestataire()).toBe(false);

--- a/models/authentication/agent/agent-connected/index.tsx
+++ b/models/authentication/agent/agent-connected/index.tsx
@@ -64,7 +64,7 @@ export class AgentConnected {
 
     if (
       !!this.email.match(
-        /[.@-]*(ext|external|externe|presta|prestataire)(s)*[.@-]/g
+        /[.@-]*(ext|external|externe|presta|prestataire|consultant)(s)*[.@-]/g
       )
     ) {
       return true;


### PR DESCRIPTION
- Changement mineur.
- Détails :
  - Some email seems to have consultant suffix

TODO
A vérifier, mais il semblerait que la DGFIP a des prestataires avec ce suffixe ?

<img width="233" alt="image" src="https://github.com/user-attachments/assets/f01ccc69-d1b9-40e6-9439-45a924b1820d" />


@MKCG 