### PR TITLE
fix: redirect user to inpi to download extrait rne

### DIFF
--- a/components/justificatifs/extrait-rne-link/index.tsx
+++ b/components/justificatifs/extrait-rne-link/index.tsx
@@ -1,3 +1,4 @@
+import routes from '#clients/routes';
 import ButtonLink from '#components-ui/button';
 import { Icon } from '#components-ui/icon/wrapper';
 import {
@@ -17,13 +18,11 @@ const ExtraitRNELink: React.FC<{
   label?: string;
   session: ISession | null;
 }> = ({ uniteLegale, label, session }) => {
+  const downloadLink = `${routes.rne.portail.pdf}?format=pdf&ids=[%22${uniteLegale.siren}%22]`;
+
   return estDiffusible(uniteLegale) ||
     hasRights(session, ApplicationRights.nonDiffusible) ? (
-    <ButtonLink
-      small
-      alt
-      to={`/justificatif-immatriculation-pdf/${uniteLegale.siren}`}
-    >
+    <ButtonLink small alt to={downloadLink} target="_blank">
       <Icon slug="download">{label || 'télécharger'}</Icon>
     </ButtonLink>
   ) : (


### PR DESCRIPTION
- Correction d'un bug.
- Détails :
  - Le changement des Access-Control-Allow-Origin de l'inpi ne permet plus de télécharger depuis une page de l'annuaire l'extrait RNE
  - L'utilisateur est redirigé vers l'INPI dans une nouvelle page, ce qui déclenche le téléchargement et referme la fenêtre aussitôt
