### PR TITLE
feat: download inpi pdf in a separate tabs like previous behaviour

### DIFF
--- a/app/(header-default)/justificatif-immatriculation-pdf/[slug]/_components/inpi-pdf-downloader.tsx
+++ b/app/(header-default)/justificatif-immatriculation-pdf/[slug]/_components/inpi-pdf-downloader.tsx
@@ -25,7 +25,7 @@ function saveAsPdf(blob: Blob, siren: string) {
 }
 
 export function InpiPDFDownloader({ siren }: { siren: string }) {
-  const downloadLink = `${routes.rne.portail.pdf}?format=pdf&ids=[%22${siren}%22]`;
+  const downloadLink = `${routes.espaceAgent.documents.inpiPdf}?siren=${siren}`;
 
   const pdf = usePDFDownloader(downloadLink);
 

--- a/app/api/inpi-pdf/route.ts
+++ b/app/api/inpi-pdf/route.ts
@@ -1,0 +1,64 @@
+import routes from '#clients/routes';
+import { EAdministration } from '#models/administrations/EAdministration';
+import { FetchRessourceException } from '#models/exceptions';
+import logErrorInSentry from '#utils/sentry';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const siren = searchParams.get('siren');
+
+  if (!siren) {
+    return NextResponse.json(
+      { message: 'Un SIREN est requis' },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const pdfUrl = `${routes.rne.portail.pdf}?format=pdf&ids=[%22${siren}%22]`;
+
+    const response = await fetch(pdfUrl, {
+      method: 'GET',
+    });
+
+    if (!response.ok) {
+      logErrorInSentry(
+        new FetchRessourceException({
+          cause: response,
+          ressource: 'Extrait RNE',
+          administration: EAdministration.INPI,
+        })
+      );
+      return NextResponse.json(
+        { message: 'Une erreur est intervenue. Nos équipes ont été notifiés.' },
+        { status: response.status }
+      );
+    }
+
+    const blob = await response.blob();
+
+    return new NextResponse(blob, {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/pdf',
+        'Content-Disposition': `attachment; filename="extrait_immatriculation_inpi_${siren}.pdf"`,
+      },
+    });
+  } catch (error) {
+    logErrorInSentry(
+      new FetchRessourceException({
+        cause: error,
+        ressource: 'Extrait RNE',
+        administration: EAdministration.INPI,
+      })
+    );
+
+    return NextResponse.json(
+      {
+        message: 'Une erreur est intervenue. Nos équipes ont été notifiés.',
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/clients/routes.ts
+++ b/clients/routes.ts
@@ -2,6 +2,7 @@ const routes = {
   espaceAgent: {
     documents: {
       download: '/api/download/espace-agent/documents/',
+      inpiPdf: '/api/inpi-pdf',
     },
   },
   apiEntreprise: {

--- a/components/justificatifs/extrait-rne-link/index.tsx
+++ b/components/justificatifs/extrait-rne-link/index.tsx
@@ -1,4 +1,3 @@
-import routes from '#clients/routes';
 import ButtonLink from '#components-ui/button';
 import { Icon } from '#components-ui/icon/wrapper';
 import {
@@ -18,11 +17,13 @@ const ExtraitRNELink: React.FC<{
   label?: string;
   session: ISession | null;
 }> = ({ uniteLegale, label, session }) => {
-  const downloadLink = `${routes.rne.portail.pdf}?format=pdf&ids=[%22${uniteLegale.siren}%22]`;
-
   return estDiffusible(uniteLegale) ||
     hasRights(session, ApplicationRights.nonDiffusible) ? (
-    <ButtonLink small alt to={downloadLink} target="_blank">
+    <ButtonLink
+      small
+      alt
+      to={`/justificatif-immatriculation-pdf/${uniteLegale.siren}`}
+    >
       <Icon slug="download">{label || 'télécharger'}</Icon>
     </ButtonLink>
   ) : (


### PR DESCRIPTION
- Amélioration technique.
- Détails :
  - Revert du commit qui déclenchait un téléchargement direct
  - Ajout d'une route api pour faire un proxy du téléchargement inpi et éviter la règle CORS


