### PR TITLE
fix: allow fallback to S3 in Groups class without throwing error and …

### DIFF
--- a/models/groups/index.ts
+++ b/models/groups/index.ts
@@ -29,7 +29,10 @@ export class Groups {
           cause: error,
         })
       );
-      throw error;
+
+      // TEMP : allow a fallback to S3 without error
+      // throw error;
+      return [];
     }
   }
 }


### PR DESCRIPTION
- Changement mineur.
- Détails :
  - Fallback sur S3 sans erreur si d-roles renvoie une erreur
  - Log sur Sentry des différences entre d-roles et S3

related to #1854
