### PR TITLE
feat: add permanent redirect for entreprise slug when it is a siren

### DIFF
--- a/app/(header-default)/entreprise/[slug]/page.tsx
+++ b/app/(header-default)/entreprise/[slug]/page.tsx
@@ -22,6 +22,7 @@ import {
 } from '#models/core/types';
 import { getRechercheEntrepriseSourcesLastModified } from '#models/recherche-entreprise-modified';
 import {
+  extractSirenOrSiretSlugFromUrl,
   shouldNotIndex,
   uniteLegalePageDescription,
   uniteLegalePageTitle,
@@ -34,6 +35,7 @@ import getSession from '#utils/server-side-helper/app/get-session';
 import { UniteLegaleImmatriculationSection } from 'app/(header-default)/entreprise/[slug]/_components/immatriculation-section';
 import UniteLegaleSummarySection from 'app/(header-default)/entreprise/[slug]/_components/summary-section';
 import { Metadata } from 'next';
+import { permanentRedirect } from 'next/navigation';
 
 export const generateMetadata = async (
   props: AppRouterProps
@@ -62,6 +64,15 @@ export default async function UniteLegalePage(props: AppRouterProps) {
     cachedGetUniteLegale(slug, isBot, page),
     getRechercheEntrepriseSourcesLastModified(),
   ]);
+
+  const extractedSiren = extractSirenOrSiretSlugFromUrl(slug);
+  if (
+    slug === extractedSiren &&
+    uniteLegale.chemin &&
+    uniteLegale.chemin !== uniteLegale.siren
+  ) {
+    permanentRedirect(`/entreprise/${uniteLegale.chemin}`);
+  }
 
   return (
     <>

--- a/cypress/e2e/fonctionnalites/unite-legale-pagination.cy.js
+++ b/cypress/e2e/fonctionnalites/unite-legale-pagination.cy.js
@@ -1,4 +1,4 @@
-const SIREN = 356000000;
+const slug = 'la-poste-direction-generale-de-la-poste-356000000';
 
 describe(`Pagination for single etablissement company`, () => {
   it('Load page even with query params', () => {
@@ -15,22 +15,22 @@ describe(`Pagination for single etablissement company`, () => {
 
 describe(`Pagination for multiple etablissement company`, () => {
   it('Has several pages', () => {
-    cy.visit(`/entreprise/${SIREN}`);
+    cy.visit(`/entreprise/${slug}`);
     cy.get('.fr-pagination').should('exist');
   });
 
   it('Has different companies on different pages', () => {
-    cy.visit(`/entreprise/${SIREN}?page=1`);
+    cy.visit(`/entreprise/${slug}?page=1`);
     const siren1 = cy.get('#etablissements tbody > tr > td:first-of-type');
 
-    cy.visit(`/entreprise/${SIREN}?page=6`);
+    cy.visit(`/entreprise/${slug}?page=6`);
     const siren2 = cy.get('#etablissements tbody > tr > td:first-of-type');
 
     cy.expect(siren1).to.not.equal(siren2);
   });
 
   it('Should color n°6 link on page 6', () => {
-    cy.visit(`/entreprise/${SIREN}?page=6`);
+    cy.visit(`/entreprise/${slug}?page=6`);
     cy.get('.fr-pagination__link[aria-current="page"]').should(
       'have.attr',
       'href',
@@ -39,26 +39,26 @@ describe(`Pagination for multiple etablissement company`, () => {
   });
 
   it('Can click on page 3', () => {
-    cy.visit(`/entreprise/${SIREN}`);
+    cy.visit(`/entreprise/${slug}`);
     cy.get('.fr-pagination__link[title="Page 3"]').click();
     cy.url().should('include', 'page=3');
   });
 
   it('Can click on previous', () => {
-    cy.visit(`/entreprise/${SIREN}?page=6`);
+    cy.visit(`/entreprise/${slug}?page=6`);
     cy.get('.fr-pagination__link--prev').click();
     cy.url().should('include', 'page=5');
   });
 
   it('Can click on next', () => {
-    cy.visit(`/entreprise/${SIREN}?page=6`);
+    cy.visit(`/entreprise/${slug}?page=6`);
     cy.get('.fr-pagination__link--next').click();
     cy.url().should('include', 'page=7');
   });
 
   // no test on last as max number of pages might evolve
   it('Can click on first', () => {
-    cy.visit(`/entreprise/${SIREN}?page=6`);
+    cy.visit(`/entreprise/${slug}?page=6`);
     cy.get('.fr-pagination__link--first').click();
     cy.url().should('include', 'page=1');
   });

--- a/cypress/e2e/recherche/research-redirections.cy.js
+++ b/cypress/e2e/recherche/research-redirections.cy.js
@@ -3,24 +3,24 @@ describe('Siren / Siret redirections', () => {
     cy.visit('/');
 
     cy.get('.fr-search-bar > input')
-      .type('123456789')
-      .should('have.value', '123456789');
+      .type('552032534')
+      .should('have.value', '552032534');
 
     cy.get('.fr-search-bar > button').click();
 
-    cy.url().should('include', '/entreprise/123456789');
+    cy.url().should('include', '/entreprise/danone-552032534');
   });
 
   it('Unformatted siren redirection', () => {
     cy.visit('/');
 
     cy.get('.fr-search-bar > input')
-      .type('123 456 789')
-      .should('have.value', '123 456 789');
+      .type('552 032 534')
+      .should('have.value', '552 032 534');
 
     cy.get('.fr-search-bar > button').click();
 
-    cy.url().should('include', '/entreprise/123456789');
+    cy.url().should('include', '/entreprise/danone-552032534');
   });
 
   it('Not found redirection', () => {
@@ -52,7 +52,7 @@ describe('Siren / Siret redirections', () => {
     cy.url().should('include', '/etablissement/48744469700428');
 
     cy.visit('/etablissement/487444697');
-    cy.url().should('include', '/entreprise/487444697');
+    cy.url().should('include', '/entreprise/essor-energies-solarsud-487444697');
   });
 
   it('Allow search request with 9 or plus digits', () => {


### PR DESCRIPTION
- Amélioration technique.
- Détails :
  - Redirect when slug is a siren and a full path is available (not non diffusible)

Closes #1824
