### PR TITLE
fix: datapass implementation glitches

### DIFF
--- a/app/(header-compte)/compte/habilitation/[demandeId]/_components/validate-group-form.tsx
+++ b/app/(header-compte)/compte/habilitation/[demandeId]/_components/validate-group-form.tsx
@@ -26,11 +26,13 @@ export default function ValidateGroupForm({
   );
 
   const submitAndCreateGroup = async () => {
+    setErrors({ groupName: undefined, emails: undefined });
+
     const groupName = (inputGroup.current?.value || '').trim();
     const emails = (inputEmails.current?.value || '').trim();
 
     const groupNameValidationError = validateGroupName(groupName);
-    const emailsValidationError = validateEmails(emails);
+    const emailsValidationError = validateEmails(emails.replaceAll('\n', ''));
 
     if (groupNameValidationError || emailsValidationError) {
       setErrors({
@@ -60,13 +62,13 @@ export default function ValidateGroupForm({
           'Impossible de configurer vos droits',
           response.error || ''
         );
+      } else {
+        router.push(
+          `/compte/habilitation/${demandeId}/succes?scopes=${encodeURIComponent(
+            response.newScopes || ''
+          )}`
+        );
       }
-
-      router.push(
-        `/compte/habilitation/${demandeId}/succes?scopes=${encodeURIComponent(
-          response.newScopes || ''
-        )}`
-      );
     } catch (error: any) {
       showErrorNotification('Impossible de configurer vos droits');
     } finally {

--- a/app/(header-compte)/compte/habilitation/[demandeId]/succes/page.tsx
+++ b/app/(header-compte)/compte/habilitation/[demandeId]/succes/page.tsx
@@ -46,7 +46,7 @@ const ConfigurezVotreGroupe = async ({
           l’espace agent de l’Annuaire des Entreprises :{' '}
         </p>
       </div>
-      {scopes.split(' ').map((s) => (
+      {(scopes || '').split(' ').map((s) => (
         <>
           <Tag>{s}</Tag>{' '}
         </>
@@ -54,7 +54,7 @@ const ConfigurezVotreGroupe = async ({
       <div className="fr-col-8">
         <p>
           Pour consultez vos droits, vous pouvez consulter la{' '}
-          <a href="/comte/accueil">page ”Mes droits”</a>.
+          <a href="/compte/accueil">page ”Mes droits”</a>.
         </p>
         <p>
           Il vous est également possible d’ajouter vos collègues a votre groupe

--- a/app/(header-compte)/compte/habilitation/[demandeId]/succes/page.tsx
+++ b/app/(header-compte)/compte/habilitation/[demandeId]/succes/page.tsx
@@ -62,12 +62,12 @@ const ConfigurezVotreGroupe = async ({
         </p>
         <ul className="fr-card__desc fr-btns-group fr-btns-group--inline-reverse fr-btns-group--inline-lg">
           <li>
-            <ButtonLink alt small>
+            <ButtonLink to="/compte/accueil" alt small>
               Voir mes droits
             </ButtonLink>
           </li>
           <li>
-            <ButtonLink to="/compte/accueil" small>
+            <ButtonLink to="/compte/mes-groupes" small>
               Gérer mes groupes
             </ButtonLink>
           </li>

--- a/components/espace-agent-components/helpers/form-validation.ts
+++ b/components/espace-agent-components/helpers/form-validation.ts
@@ -16,9 +16,16 @@ export const validateEmail = (email: string): ValidationErrors => {
 export const validateEmails = (emailList: string): ValidationErrors => {
   const emails = emailList.split(',').filter((email) => Boolean(email.trim()));
 
-  return emails.some((email) => validateEmail(email))
-    ? 'Au moins une des adresses emails n’est pas valide'
-    : null;
+  const invalidEmails = emails.filter((email) => validateEmail(email));
+
+  if (invalidEmails.length === 0) {
+    return null;
+  }
+
+  const plural = invalidEmails.length === 1 ? '' : 's';
+  return `Adresse${plural} email${plural} invalide${plural} : ${invalidEmails.join(
+    ', '
+  )}`;
 };
 
 export const validateGroupName = (name: string): ValidationErrors => {


### PR DESCRIPTION
closes #1943 

- error in workflow still displaying success page
- typo in `/compte/accueil` link
- form validation was broken
- email validation lacked good feedback
- missing `mes-groupes` link