### PR TITLE
feat: update group management - remove beta tag and duplaicate accueil

### DIFF
--- a/app/(header-compte)/compte/accueil-test/page.tsx
+++ b/app/(header-compte)/compte/accueil-test/page.tsx
@@ -2,6 +2,7 @@ import { Warning } from '#components-ui/alerts';
 import { Badge } from '#components-ui/badge';
 import ButtonLink from '#components-ui/button';
 import FullWidthContainer from '#components-ui/container';
+import { Icon } from '#components-ui/icon/wrapper';
 import AgentNavigation from '#components/espace-agent-components/agent-navigation';
 import { FullTable } from '#components/table/full';
 import {
@@ -34,7 +35,7 @@ const CompteAgentAccueil = async () => {
   const appRights = Object.values(ApplicationRights)
     .filter((scope) => scope !== ApplicationRights.isAgent)
     .map((scope) => [scope, hasRights(session, scope)])
-    .filter(([a, b]) => b);
+    .sort((a, b) => (a[1] ? -1 : 1));
 
   return (
     <>
@@ -165,12 +166,17 @@ const CompteAgentAccueil = async () => {
           Voici la liste des données auxquelles vous avez actuellement accès en
           tant qu’agent public.
         </p>
-
+        <br />
         <FullTable
-          head={['Données', 'Droits']}
+          head={['Données', 'Cadre légal', 'Droits']}
           body={appRights.map(([a, b]) => {
             return [
               a,
+              b ? (
+                <>Agent public</>
+              ) : (
+                <Icon slug="lockFill">Sous habilitation</Icon>
+              ),
               <Badge
                 icon={b ? 'open' : 'closed'}
                 label={b ? 'Oui' : 'Non'}
@@ -181,6 +187,38 @@ const CompteAgentAccueil = async () => {
           })}
         />
       </div>
+
+      {(true || !session?.user?.isSuperAgent) && (
+        <div className="content-container">
+          <h2>Les données supplémentaires</h2>
+          <p>
+            Lorsque le tableau indique{' '}
+            <Badge
+              icon={'closed'}
+              label={'Non'}
+              backgroundColor="#ddd"
+              fontColor="#666"
+            />
+            , cela signifie que ces données nécessitent une habilitation.
+          </p>
+          <p>
+            En faisant une demande, vous pouvez obtenir des droits
+            supplémentaires si votre mission concerne :
+          </p>
+          <ul>
+            <li>La fraude</li>
+            <li>Les marchés publics</li>
+            <li>Les subventions aux associations</li>
+            <li>Les aides publiques</li>
+          </ul>
+          <br />
+          <ButtonLink
+            to={`${process.env.DATAPASS_URL}/demandes/annuaire-des-entreprises/nouveau`}
+          >
+            Demander une habilitation
+          </ButtonLink>
+        </div>
+      )}
     </>
   );
 };

--- a/components/espace-agent-components/agent-navigation-link.tsx
+++ b/components/espace-agent-components/agent-navigation-link.tsx
@@ -6,11 +6,9 @@ import { usePathname } from 'next/navigation';
 export default function AgentNavigationLink({
   href,
   label,
-  isBeta = false,
 }: {
   href: string;
   label: string;
-  isBeta: boolean;
 }) {
   const pathname = usePathname();
 
@@ -21,11 +19,6 @@ export default function AgentNavigationLink({
       key={href}
       href={href}
     >
-      {isBeta && (
-        <span className="fr-badge fr-mr-1w fr-badge--new fr-badge--sm">
-          Beta
-        </span>
-      )}
       {label}
     </Link>
   );

--- a/components/espace-agent-components/agent-navigation.tsx
+++ b/components/espace-agent-components/agent-navigation.tsx
@@ -4,8 +4,8 @@ import AgentNavigationLink from './agent-navigation-link';
 
 export default async function AgentNavigation() {
   const navLinks = [
-    { label: 'Mon espace', href: '/compte/accueil', isBeta: false },
-    { label: 'Mes groupes', href: '/compte/mes-groupes', isBeta: true },
+    { label: 'Mon espace', href: '/compte/accueil' },
+    { label: 'Mes groupes', href: '/compte/mes-groupes' },
   ];
   return (
     <nav
@@ -17,13 +17,8 @@ export default async function AgentNavigation() {
       }}
     >
       <div style={{ display: 'flex', gap: '2rem' }}>
-        {navLinks.map(({ label, href, isBeta }) => (
-          <AgentNavigationLink
-            href={href}
-            label={label}
-            key={href}
-            isBeta={isBeta}
-          />
+        {navLinks.map(({ label, href }) => (
+          <AgentNavigationLink href={href} label={label} key={href} />
         ))}
       </div>
       <div>

--- a/components/espace-agent-components/group-management/group-item.tsx
+++ b/components/espace-agent-components/group-management/group-item.tsx
@@ -1,7 +1,7 @@
 import { IRolesDataRoles, IRolesDataUser } from '#clients/roles-data/interface';
+import ButtonLink from '#components-ui/button';
 import { FullTable } from '#components/table/full';
 import { IRolesDataGroup } from '#models/authentication/group/groups';
-import { pluralize } from '#utils/helpers';
 import { Fragment, useMemo } from 'react';
 import AddUserModal from './update-modals/add-user';
 import DeleteUserButton from './update-modals/delete-user';
@@ -83,44 +83,47 @@ export function GroupItem({
                 />
               )}
             </div>
-            <p>
-              Ce groupe contient {group.users.length} membre
-              {pluralize(group.users)}
+            <div>
+              <strong>Habilitation :</strong>{' '}
               {group.contract_description ? (
-                <>
-                  {' '}
-                  et possède le contrat{' '}
-                  <strong>{group.contract_description}</strong>
-                </>
-              ) : null}
-              {group.contract_url ? (
-                <>
-                  {' '}
-                  (
+                group.contract_url ? (
                   <a
                     href={group.contract_url}
                     target="_blank"
                     rel="noopener noreferrer"
                   >
-                    consulter le contrat
+                    {group.contract_description}
                   </a>
-                  )
-                </>
-              ) : null}
-              .
-              {group.scopes && group.scopes.length > 0 ? (
-                <>
-                  {' '}
-                  Ce contrat donne accès aux droits suivants :{' '}
-                  {group.scopes.map((scope) => (
+                ) : (
+                  <strong>{group.contract_description}</strong>
+                )
+              ) : (
+                <i>Aucune habilitation</i>
+              )}
+            </div>
+            <div>
+              <strong>Données accessibles :</strong>{' '}
+              {group.scopes && group.scopes.length > 0
+                ? group.scopes.map((scope) => (
                     <Fragment key={scope}>
                       <span className="fr-badge fr-badge--sm">{scope}</span>
                       &nbsp;
                     </Fragment>
-                  ))}
-                </>
-              ) : null}
-            </p>
+                  ))
+                : null}
+            </div>
+            {isAdmin && (
+              <div>
+                <p>
+                  Votre mission ou le cadre juridique de ce groupe est modifié ?
+                  En tant qu’administrateur, modifiez votre habilitation pour
+                  accèder à des données supplémentaires.
+                </p>
+                <ButtonLink alt small to={group.contract_url}>
+                  Modifier l’habilitation
+                </ButtonLink>
+              </div>
+            )}
           </div>
           {!isAdmin ? (
             <NotAdminTable group={group} currentUserEmail={currentUserEmail} />
@@ -142,7 +145,7 @@ export function GroupItem({
               </div>
 
               <FullTable
-                head={['Membre', 'Rôle', 'Action']}
+                head={[`Membres (${group.users.length})`, 'Rôle', 'Action']}
                 columnWidths={['65%']}
                 body={group.users.map((user) => [
                   <div style={{ flexGrow: 1 }}>

--- a/components/header/menu/index.tsx
+++ b/components/header/menu/index.tsx
@@ -45,9 +45,6 @@ const Menu: React.FC<{
         </a>
         {session?.user?.isSuperAgent && (
           <a aria-label="Gestion de mes groupes" href={'/compte/mes-groupes'}>
-            <span className="fr-badge fr-mr-1w fr-badge--new fr-badge--sm">
-              Beta
-            </span>
             Mes groupes
           </a>
         )}


### PR DESCRIPTION
closes #1964 

- remove beta label
- create a  /accueil-test that is an improved version of /accueil open for UX testing 
- entirely remove datapass link from /accueil
- add link to habilitation in /mes-groupes