### PR TITLE
fix: fix urssaf logo

### DIFF
--- a/public/images/logos/urssaf.svg
+++ b/public/images/logos/urssaf.svg
@@ -1,1 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 81.2 130.5" style="enable-background:new -28.6 0 621.2 200.5" xml:space="preserve"><path d="M.2 48.8a26.3 26.3 0 1 0 52.5 0 26.3 26.3 0 0 0-52.5 0" style="fill:#1ecad3"/><path d="M52.5 75h52.1c0 29-23.3 52.6-52.1 52.6V75z" style="fill:#90b3e6"/><path d="M104.6 22.6V75H52.5c0-29 23.3-52.5 52.1-52.5" style="fill:#0071ce"/><path d="M52.5 75H.4c0 29 23.3 52.6 52 52.6V75z" style="fill:#d0ddf4"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 95 96">
+  <path fill="#1ECAD3" d="M.2 24.3a23.8 23.8 0 1 0 47.6 0 23.8 23.8 0 0 0-47.6 0Z" />
+  <path fill="#90B3E6" d="M47.7 48.1H95a47.5 47.5 0 0 1-47.3 47.7V48.1Z" />
+  <path fill="#0071CE" d="M95 .5V48H47.7A47.5 47.5 0 0 1 95 .5Z" />
+  <path fill="#D0DDF4" d="M47.7 48.1H.3a47.5 47.5 0 0 0 47.4 47.7V48.1Z" />
+</svg>


### PR DESCRIPTION
- Changement mineur.
- Détails :
  - Mise à jour du logo urssaf

<img width="901" height="531" alt="image" src="https://github.com/user-attachments/assets/91826b2e-e891-4549-add7-dee90a1472b3" />


Closes #1906