### PR TITLE
fix: admin can auto downgrade their role

### DIFF
--- a/components/espace-agent-components/group-management/group-item.tsx
+++ b/components/espace-agent-components/group-management/group-item.tsx
@@ -156,7 +156,7 @@ export function GroupItem({
                       </span>
                     )}
                   </div>,
-                  user.email !== currentUserEmail ? (
+                  user.email !== currentUserEmail || adminCount >= 2 ? (
                     <UpdateUserSelect
                       user={user}
                       groupId={group.id}


### PR DESCRIPTION
- Changement mineur.
- Détails :
  - Un admin peut se passer utilisateur si il y a un autre admin

Closes #1938