### PR TITLE
fix: improve wording footer export sirene

### DIFF
--- a/components/footer/index.tsx
+++ b/components/footer/index.tsx
@@ -61,7 +61,7 @@ const Footer = () => (
               <ul className="fr-footer__top-list">
                 <li>
                   <a className="fr-footer__top-link" href="/export-sirene">
-                    Export CSV depuis la base Sirene
+                    Configurer un export Sirene
                   </a>
                 </li>
               </ul>

--- a/components/footer/index.tsx
+++ b/components/footer/index.tsx
@@ -56,7 +56,7 @@ const Footer = () => (
               </ul>
               <br />
               <strong className="fr-footer__top-cat">
-                Extraire une liste d‘entreprises du répertoire Sirene
+                Générer une liste CSV à partir du répertoire Sirene
               </strong>
               <ul className="fr-footer__top-list">
                 <li>

--- a/components/footer/index.tsx
+++ b/components/footer/index.tsx
@@ -54,6 +54,17 @@ const Footer = () => (
                   </a>
                 </li>
               </ul>
+              <br />
+              <strong className="fr-footer__top-cat">
+                Extraire une liste d‘entreprises du répertoire Sirene
+              </strong>
+              <ul className="fr-footer__top-list">
+                <li>
+                  <a className="fr-footer__top-link" href="/export-sirene">
+                    Export CSV depuis la base Sirene
+                  </a>
+                </li>
+              </ul>
             </div>
             <div className="fr-col-12 fr-col-sm-4 fr-col-md-4">
               <strong className="fr-footer__top-cat">
@@ -207,11 +218,6 @@ const Footer = () => (
                 <li>
                   <a className="fr-footer__top-link" href="/a-propos/equipe">
                     Équipe
-                  </a>
-                </li>
-                <li>
-                  <a className="fr-footer__top-link" href="/export-sirene">
-                    Générez une liste CSV à partir du répertoire Sirene
                   </a>
                 </li>
               </ul>


### PR DESCRIPTION
- Changement mineur.
- Détails :
  - Amélioration du wording sur le footer pour l'export Sirene

<img width="995" height="328" alt="image" src="https://github.com/user-attachments/assets/6eb10ce8-7de9-40a8-a47e-eb756bb7f049" />

