### PR TITLE
fix: object object label in stats

### DIFF
--- a/components/table/simple.tsx
+++ b/components/table/simple.tsx
@@ -78,7 +78,12 @@ const labelToString = (label: string | JSX.Element): string => {
     return label.props.tooltipLabel;
   }
   if (label?.props?.children) {
-    return labelToString(label.props.children);
+    if (typeof label?.props?.children === 'string') {
+      return label?.props?.children;
+    }
+    if (typeof label?.props?.children?.props?.children === 'string') {
+      return label?.props?.children?.props?.children;
+    }
   }
   return 'unknown label';
 };


### PR DESCRIPTION
- Correction d'un bug.
- Détails :
  - Le label de ce qui a été copié collé était mal loggé quand ce n'était pas une chaîne de caractère
 
Label "object object" :
<img width="421" height="298" alt="image" src="https://github.com/user-attachments/assets/b78ee8c2-0fee-41c3-9978-3cc6bd24579b" />
