### PR TITLE
[Bug]fix(spectacle vivant): add statut `expiré`

### DIFF
--- a/components/labels-and-certificates/entrepreneur-spectacles/index.tsx
+++ b/components/labels-and-certificates/entrepreneur-spectacles/index.tsx
@@ -187,6 +187,15 @@ const Validity = ({ statut = '', dateDeValidite = '' }) => {
           <Tag color="error">Invalide</Tag>
         </InformationTooltip>
       );
+    case 'expiré':
+      return (
+        <InformationTooltip
+          tabIndex={0}
+          label="La licence est arrivée à expiration de sa durée de validité."
+        >
+          <Tag color="error">Expiré</Tag>
+        </InformationTooltip>
+      );
     default:
       return <Tag color="new">Etat inconnu</Tag>;
   }


### PR DESCRIPTION
Test example : https://annuaire-entreprises.data.gouv.fr/labels-certificats/497800714
Before:
<img width="1205" height="133" alt="Screenshot 2025-09-25 at 15 22 27" src="https://github.com/user-attachments/assets/d36f363e-3db3-4a90-bdf4-7446d94dcac3" />
After:
<img width="1245" height="808" alt="Screenshot 2025-09-25 at 15 20 56" src="https://github.com/user-attachments/assets/835f44bf-ec62-4fa9-8bf3-8271b511cf87" />
