### PR TITLE
[Bug]fix(djepva): replace link to api and email

### DIFF
--- a/data/administrations/djepva.yml
+++ b/data/administrations/djepva.yml
@@ -2,12 +2,12 @@ slug: djepva
 short: DJEPVA
 site: https://www.jeunes.gouv.fr/organisation-du-ministere-184
 long: La direction de la jeunesse de l'éducation populaire et de la vie associative (DJEPVA)
-contact: djepva.dir@jeunesse-sports.gouv.fr
+contact: mailto:djepva.dir@jeunesse-sports.gouv.fr
 apiMonitors:
   - apiName: API Association
     apiSlug: rna
     updownIoId: phbs
-    apiDocumentationLink: https://www.associations.gouv.fr/les-api-et-autres-outils.html
+    apiDocumentationLink: https://www.associations.gouv.fr/lapi-association-et-le-referentiel-des-associations
   - label: API data.subvention
     apiSlug: data-subvention
     isProtected: true


### PR DESCRIPTION
This PR:
* Updates link to DJEPVA API
* Fixes link to DJEPVA contact. Before the link forwarded to https://annuaire-entreprises.data.gouv.fr/donnees/djepva.dir@jeunesse-sports.gouv.fr/. i am not sure that my fix works @AlanChauchet @XavierJp 
