### PR TITLE
feat(uniteLegale): [1889] display unite legale info other than dirigeants for protected non EI

### DIFF
--- a/components/search-results/results-list.tsx
+++ b/components/search-results/results-list.tsx
@@ -2,6 +2,7 @@ import type React from "react";
 import UniteLegaleBadge from "#components/unite-legale-badge";
 import { Icon } from "#components-ui/icon/wrapper";
 import IsActiveTag from "#components-ui/tag/is-active-tag";
+import { estDiffusible } from "#models/core/diffusion";
 import { estActif } from "#models/core/etat-administratif";
 import { isCollectiviteTerritoriale } from "#models/core/types";
 import type { IDirigeants } from "#models/rne/types";
@@ -17,12 +18,13 @@ type IProps = {
 
 const DirigeantsOrElusList: React.FC<{
   dirigeantsOrElus: IDirigeants;
-}> = ({ dirigeantsOrElus }) => {
+  isDiffusible: boolean;
+}> = ({ dirigeantsOrElus, isDiffusible }) => {
   const displayMax = 5;
   const firstFive = dirigeantsOrElus.slice(0, displayMax);
   const moreCount = Math.max(dirigeantsOrElus.length - displayMax, 0);
 
-  if (dirigeantsOrElus.length === 0) {
+  if (dirigeantsOrElus.length === 0 || !isDiffusible) {
     return null;
   }
 
@@ -100,6 +102,7 @@ const ResultItem: React.FC<{
               ? result.colter.elus
               : result.dirigeants
           }
+          isDiffusible={estDiffusible(result)}
         />
         <div>
           <Icon slug="mapPin">

--- a/models/core/types.ts
+++ b/models/core/types.ts
@@ -269,15 +269,14 @@ export const isEntrepreneurIndividuel = (
   uniteLegaleOrEtablissement: IUniteLegale | IEtablissement
 ): boolean => uniteLegaleOrEtablissement.complements.estEntrepreneurIndividuel;
 
-export const isPersonneMorale = (
-  uniteLegaleOrEtablissement: IUniteLegale
-): boolean =>
+export const isPersonneMorale = (uniteLegale: IUniteLegale): boolean =>
   !(
-    isEntrepreneurIndividuel(uniteLegaleOrEtablissement) ||
-    isNotPersonneMoraleFromNatureJuridique(
-      uniteLegaleOrEtablissement.natureJuridique
-    )
+    isEntrepreneurIndividuel(uniteLegale) ||
+    isNotPersonneMoraleFromNatureJuridique(uniteLegale.natureJuridique)
   );
+
+export const isPersonnePhysique = (uniteLegale: IUniteLegale): boolean =>
+  !isPersonneMorale(uniteLegale);
 
 export interface ICollectiviteTerritoriale
   extends Omit<IUniteLegale, "colter"> {

--- a/models/search/index.ts
+++ b/models/search/index.ts
@@ -1,10 +1,12 @@
 import { HttpBadRequestError, HttpNotFound } from "#clients/exceptions";
 import clientSearchRechercheEntreprise from "#clients/recherche-entreprise";
+import { anonymiseUniteLegale, ISTATUTDIFFUSION } from "#models/core/diffusion";
 import {
   FetchRechercheEntrepriseException,
   type IEtablissement,
   IsLikelyASirenOrSiretException,
   type IUniteLegale,
+  isPersonnePhysique,
   NotEnoughParamsException,
 } from "#models/core/types";
 import { Exception } from "#models/exceptions";
@@ -17,6 +19,7 @@ import {
 } from "#utils/helpers";
 import { isPersonneMorale } from "#utils/helpers/is-personne-morale";
 import { logWarningInSentry } from "#utils/sentry";
+import getSession from "#utils/server-side-helper/app/get-session";
 
 export interface ISearchResult extends IUniteLegale {
   nombreEtablissements: number;
@@ -112,17 +115,29 @@ export const searchWithoutProtectedSiren = async (
   page: number,
   searchFilterParams: SearchFilterParams
 ): Promise<ISearchResults> => {
+  const session = await getSession();
   const results = await search(searchTerm, page, searchFilterParams);
-  const newResults = [];
+  const newResults: ISearchResult[] = [];
 
   for (let i = 0; i < results.results.length; i++) {
     const currentResult = results.results[i];
-    if (await isProtectedSiren(currentResult.siren)) {
+    const isProtected = await isProtectedSiren(currentResult.siren);
+
+    if (isProtected) {
+      currentResult.statutDiffusion = ISTATUTDIFFUSION.PROTECTED;
+      currentResult.siege.statutDiffusion = ISTATUTDIFFUSION.PROTECTED;
+      currentResult.matchingEtablissements.forEach((etablissement) => {
+        etablissement.statutDiffusion = ISTATUTDIFFUSION.PROTECTED;
+      });
+    }
+
+    if (isProtected && isPersonnePhysique(currentResult)) {
       results.resultCount -= 1;
     } else {
-      newResults.push(currentResult);
+      newResults.push(anonymiseUniteLegale(currentResult, session));
     }
   }
+
   results.results = newResults;
   return results;
 };

--- a/utils/helpers/checks.ts
+++ b/utils/helpers/checks.ts
@@ -1,9 +1,6 @@
 import { estDiffusible } from "#models/core/diffusion";
 import { estActif } from "#models/core/etat-administratif";
-import {
-  type IUniteLegale,
-  isEntrepreneurIndividuel,
-} from "#models/core/types";
+import { type IUniteLegale, isPersonnePhysique } from "#models/core/types";
 
 export const isEntrepreneurIndividuelFromNatureJuridique = (
   natureJuridique: string
@@ -28,8 +25,8 @@ export const isTwoMonthOld = (dateAsString: string) => {
  * Return true if an uniteLegale should be **ignored** by indexing bots
  */
 export const shouldNotIndex = (uniteLegale: IUniteLegale) => {
-  if (isEntrepreneurIndividuel(uniteLegale)) {
-    // we dont index EI
+  if (isPersonnePhysique(uniteLegale)) {
+    // we dont index personnes physiques
     return true;
   }
   if (!estActif(uniteLegale)) {


### PR DESCRIPTION
- Changement mineur.
- Zones impactées : page entreprise.
- Détails :
  - Ne cache plus les informations autres que les dirigeants pour les non EI protégées
  - Les sociétés protégées sont indexables

related to https://github.com/annuaire-entreprises-data-gouv-fr/site/issues/1889
