### PR TITLE
fix: update notify action reference to shared repository

### DIFF
--- a/.github/workflows/ping-seo-repo.yml
+++ b/.github/workflows/ping-seo-repo.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Notify failure
         if: failure()
-        uses: ./.github/actions/notify
+        uses: annuaire-entreprises-data-gouv-fr/github-actions/.github/actions/notify@main
         with:
           message: '🚨 ${{ github.event.repository.name }} : trigger seo workflow failed'
           hook: ${{ secrets.DEV_EVENT_HOOK }}


### PR DESCRIPTION
The notify action has been moved to the shared github-actions repository. This commit updates the workflow to use the centralized action.

Refs #2054
