### PR TITLE
fix: use GitHub App authentication for SEO workflow trigger

### DIFF
--- a/.github/workflows/ping-seo-repo.yml
+++ b/.github/workflows/ping-seo-repo.yml
@@ -15,9 +15,18 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Generate GitHub App token
+        id: generate-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.SEO_APP_ID }}
+          private-key: ${{ secrets.SEO_APP_PRIVATE_KEY }}
+          owner: annuaire-entreprises-data-gouv-fr
+          repositories: seo
+
       - name: Trigger workflow in SEO repository
         env:
-          GH_TOKEN: ${{ secrets.GH_PAT_TOKEN }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           echo "Triggering workflow seo.yml in repository: annuaire-entreprises-data-gouv-fr/seo"
           # Trigger a workflow dispatch event : https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#create-a-workflow-dispatch-event


### PR DESCRIPTION
## Summary

Fixed the failing SEO workflow trigger by replacing the personal access token (PAT) (linked to an org member) with GitHub App authentication (linked to the org itself).

**Changes:**
- Added GitHub App token generation step using `actions/create-github-app-token@v2`
- Replaced `secrets.GH_PAT_TOKEN` with the generated app token
- Deleted the unused `GH_PAT_TOKEN` secret

**Setup completed:**
- Created GitHub App `annuaire-entreprises-seo-trigger` (ID: 2072320)
- Added `SEO_APP_ID` variable and `SEO_APP_PRIVATE_KEY` secret to repository
- Installed app on `site` and `seo` repositories

This ensures the workflow is not tied to any individual team member and follows GitHub's recommended approach for organization-level automation.

Fixes #2054