### PR TITLE
fix(map): hides coordinates for invalid map

### DIFF
--- a/components/map/map-etablissement.tsx
+++ b/components/map/map-etablissement.tsx
@@ -80,10 +80,6 @@ export function MapEtablissement({
           <br />
           Cela peut-être dû à un problème d’affichage, ou à un problème dans les
           coordonnées de l’établissement.
-          <br />
-          (coordonnées [{etablissement?.latitude || "⎽"}°,{" "}
-          {etablissement?.longitude || "⎽"}
-          °])
         </i>
       )}
     </div>


### PR DESCRIPTION
- Correction d'un bug.
- Zones impactées : Etablissement - Map.
- Détails :
  - Suppression des coordonnées du message d'erreur lorsqu'elles sont invalides

related to #1942 
