### PR TITLE
feat: use a dedicated exception and improve error page

### DIFF
--- a/app/(header-connexion)/connexion/habilitation/refusee/page.tsx
+++ b/app/(header-connexion)/connexion/habilitation/refusee/page.tsx
@@ -1,13 +1,15 @@
 import type { Metadata } from "next";
 import { ConnexionSubLayout } from "#components-ui/connexion-layout";
 import connexionRefusedPicture from "#components-ui/illustrations/connexion-failed";
+import type { AppRouterProps } from "#utils/server-side-helper/extract-params";
 
 export const metadata: Metadata = {
   title: "Accès à l’espace agent refusé",
   robots: "noindex, nofollow",
 };
 
-export default function RefusedConnexionPage() {
+export default async function RefusedConnexionPage(props: AppRouterProps) {
+  const searchParams = await props.searchParams;
   return (
     <ConnexionSubLayout img={connexionRefusedPicture}>
       <h1>L’accès à l’espace agent vous est refusé</h1>
@@ -16,8 +18,12 @@ export default function RefusedConnexionPage() {
         public.
       </div>
       <p>
-        Votre organisation n’est pas une administration et par conséquent,
-        l’accès à l’espace agent vous est refusé.
+        L’organisation à laquelle vous appartenez (
+        <a href={`/entreprise/${searchParams.siren}`}>
+          {searchParams.name || searchParams.siren}
+        </a>
+        ) n’est pas une administration et par conséquent, l’accès à l’espace
+        agent vous est refusé.
       </p>
       <a href="/">← Retourner au moteur de recherche</a>
     </ConnexionSubLayout>

--- a/app/api/auth/agent-connect/callback/route.ts
+++ b/app/api/auth/agent-connect/callback/route.ts
@@ -1,11 +1,11 @@
 import { NextResponse } from "next/server";
 import { proConnectAuthenticate } from "#clients/authentication/pro-connect/strategy";
-import { HttpForbiddenError } from "#clients/exceptions";
 import { AgentConnected } from "#models/authentication/agent/agent-connected";
 import {
   AgentConnectionFailedException,
   CanRequestAuthorizationException,
   NeedASiretException,
+  OrganisationNotAnAdministration,
   PrestataireException,
 } from "#models/authentication/authentication-exceptions";
 import { Information } from "#models/exceptions";
@@ -85,9 +85,10 @@ export const GET = withSession(async function callbackRoute(req) {
         getBaseUrl() + "/connexion/habilitation/administration-inconnue"
       );
     }
-    if (e instanceof HttpForbiddenError) {
+    if (e instanceof OrganisationNotAnAdministration) {
       return NextResponse.redirect(
-        getBaseUrl() + "/connexion/habilitation/refusee"
+        getBaseUrl() +
+          `/connexion/habilitation/refusee?siren=${e.context.siren}&name=${e.context.details}`
       );
     }
     return NextResponse.redirect(getBaseUrl() + "/connexion/echec-connexion");

--- a/models/authentication/agent/agent-connected/index.tsx
+++ b/models/authentication/agent/agent-connected/index.tsx
@@ -113,7 +113,7 @@ export class AgentConnected {
   }
 
   async getOrganisationHabilitation() {
-    const organisation = new AgentOrganisation(this.idpId, this.siret);
+    const organisation = new AgentOrganisation(this.siret);
     return await organisation.getHabilitationLevel();
   }
 

--- a/models/authentication/agent/organisation/index.test.ts
+++ b/models/authentication/agent/organisation/index.test.ts
@@ -4,29 +4,20 @@ import { AgentOrganisation } from ".";
 
 describe("AgentOrganisation class", () => {
   test("ADEME passes", async () => {
-    const orga = new AgentOrganisation(
-      "4106b71b-094a-48f0-974a-cb2c2a9649b3",
-      verifySiret("38529030900454")
-    );
+    const orga = new AgentOrganisation(verifySiret("38529030900454"));
 
     const habilitation = await orga.getHabilitationLevel();
     expect(habilitation.isSuperAgent).toBe(false);
   });
   test("DINUM passes", async () => {
-    const orga = new AgentOrganisation(
-      "4106b71b-094a-48f0-974a-cb2c2a9649b3",
-      verifySiret("13002526500013")
-    );
+    const orga = new AgentOrganisation(verifySiret("13002526500013"));
 
     const habilitation = await orga.getHabilitationLevel();
     expect(habilitation.isSuperAgent).toBe(false);
   });
 
   test("RATP fails", async () => {
-    const orga = new AgentOrganisation(
-      "4106b71b-094a-48f0-974a-cb2c2a9649b3",
-      verifySiret("77566343801906")
-    );
+    const orga = new AgentOrganisation(verifySiret("77566343801906"));
 
     await expect(async () => await orga.getHabilitationLevel()).rejects.toThrow(
       CanRequestAuthorizationException
@@ -34,10 +25,7 @@ describe("AgentOrganisation class", () => {
   });
 
   test("GIP Inclusion OK", async () => {
-    const orga = new AgentOrganisation(
-      "4106b71b-094a-48f0-974a-cb2c2a9649b3",
-      verifySiret("13003013300016")
-    );
+    const orga = new AgentOrganisation(verifySiret("13003013300016"));
 
     const habilitation = await orga.getHabilitationLevel();
     expect(habilitation.isSuperAgent).toBe(false);

--- a/models/authentication/authentication-exceptions.ts
+++ b/models/authentication/authentication-exceptions.ts
@@ -1,4 +1,5 @@
 import { Exception } from "#models/exceptions";
+import type { Siren } from "#utils/helpers";
 
 export class AgentConnectionFailedException extends Exception {
   constructor(args: { cause?: any; context?: { slug: string } }) {
@@ -39,6 +40,18 @@ export class NeedASiretException extends Exception {
       message,
       context: {
         details: userId,
+      },
+    });
+  }
+}
+
+export class OrganisationNotAnAdministration extends Exception {
+  constructor(siren: Siren, name: string) {
+    super({
+      name: "OrganisationIsNotAnAdministration",
+      context: {
+        siren,
+        details: name,
       },
     });
   }


### PR DESCRIPTION
- use a dedicated exception instead of a catch all HttpForbidden that could theoretically have side effects
- add the name of the organisation and a link to main page
- refactor AgentOrganisation, removing useless code

closes #2131 