### PR TITLE
chore(next): enable nextjs streaming

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -70,6 +70,15 @@ const nextConfig: NextConfig = {
         ],
       },
       {
+        source: "/:path*{/}?",
+        headers: [
+          {
+            key: "X-Accel-Buffering",
+            value: "no",
+          },
+        ],
+      },
+      {
         source: "/api/share/button:id(\\d+)",
         headers: [
           {


### PR DESCRIPTION
fixes streaming not working with the Nginx reverse proxy (https://nextjs.org/docs/app/guides/self-hosting#streaming-and-suspense)