### PR TITLE
fix(antibot): adds middleware to skip bot requests

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,7 +1,5 @@
-import { getIronSession } from "iron-session";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import type { ISession } from "#models/authentication/user/session";
 import { Exception } from "#models/exceptions";
 import {
   extractSirenOrSiretFromRechercherUrl,
@@ -11,7 +9,6 @@ import {
 } from "#utils/helpers";
 import logErrorInSentry from "#utils/sentry";
 import { getBaseUrl } from "#utils/server-side-helper/get-base-url";
-import { sessionOptions, setVisitTimestamp } from "#utils/session";
 
 const shouldRedirect = (path: string, search: string, url: string) => {
   try {
@@ -89,21 +86,12 @@ export async function middleware(request: NextRequest) {
     requestHeaders.set("x-redirected", isRedirected);
   }
 
-  const response = NextResponse.next({
+  return NextResponse.next({
     request: {
       // Apply new request headers
       headers: requestHeaders,
     },
   });
-
-  const session = await getIronSession<ISession>(
-    request,
-    response,
-    sessionOptions
-  );
-  await setVisitTimestamp(session);
-
-  return response;
 }
 
 export const config = {

--- a/models/authentication/user/session.ts
+++ b/models/authentication/user/session.ts
@@ -1,7 +1,6 @@
 import type { IAgentInfo } from "../agent";
 
 export type ISession = {
-  lastVisitTimestamp?: number;
   user: IAgentInfo | null;
 
   // pro connect

--- a/server-fetch/agent/middlewares.ts
+++ b/server-fetch/agent/middlewares.ts
@@ -10,6 +10,7 @@ import { Exception } from "#models/exceptions";
 import {
   type Fetcher,
   type IFetcherFactory,
+  ignoreBot,
   withErrorHandler,
 } from "../middlewares";
 
@@ -74,6 +75,8 @@ class AgentFetcherFactory<Args extends any[], Result>
             message: "Unauthorized: Agent access required",
           });
         }
+
+        await ignoreBot();
 
         if (this._needsRateLimit) {
           await verifyAgentRateLimit(session?.user?.email);

--- a/server-fetch/middlewares.ts
+++ b/server-fetch/middlewares.ts
@@ -1,3 +1,6 @@
+import { headers } from "next/headers";
+import { userAgent } from "next/server";
+import { HttpUnauthorizedError } from "#clients/exceptions";
 import type { IDataFetchingState } from "#models/data-fetching";
 import { convertErrorToFetchingState } from "#utils/helpers/convert-error";
 import { handleServerError } from "#utils/server-side-helper/handle-server-error";
@@ -14,6 +17,15 @@ export function withErrorHandler<T, Args extends any[]>(
       return convertErrorToFetchingState(formattedError.status);
     }
   };
+}
+
+export async function ignoreBot() {
+  const resolvedHeaders = await headers();
+  const { isBot } = userAgent({ headers: resolvedHeaders });
+
+  if (isBot) {
+    throw new HttpUnauthorizedError("Antibot activated : user is a bot");
+  }
 }
 
 export type Fetcher<Args extends any[], Result> = (

--- a/server-fetch/public/middlewares.ts
+++ b/server-fetch/public/middlewares.ts
@@ -2,6 +2,7 @@ import type { IDataFetchingState } from "#models/data-fetching";
 import {
   type Fetcher,
   type IFetcherFactory,
+  ignoreBot,
   withErrorHandler,
 } from "../middlewares";
 
@@ -15,7 +16,11 @@ class PublicFetcherFactory<Args extends any[], Result>
   ) => Promise<
     Result | Exclude<IDataFetchingState, IDataFetchingState.LOADING>
   > {
-    return withErrorHandler(async (...args: Args) => this.loader(...args));
+    return withErrorHandler(async (...args: Args) => {
+      await ignoreBot();
+
+      return this.loader(...args);
+    });
   }
 }
 

--- a/utils/session/index.ts
+++ b/utils/session/index.ts
@@ -14,11 +14,6 @@ export const sessionOptions: SessionOptions = {
   ttl: 43_200, // 12h
 };
 
-export async function setVisitTimestamp(session: IronSession<ISession>) {
-  session.lastVisitTimestamp = new Date().getTime();
-  await session.save();
-}
-
 /**
  * Utils for AgentConnect session
  */


### PR DESCRIPTION
Prevents bots from triggering requests like tva, eori and rne.

This also removes the whole "lastVisitTimestamp" logic previously used to check if the user visited a page before triggering one of these requests. Now, they directly access the page with the requests triggered so it doesn't make sense anymore.