### PR TITLE
feat(server): aborts short requests on client cancel

### DIFF
--- a/app/(header-default)/annonces/[slug]/_components/observations-rne.tsx
+++ b/app/(header-default)/annonces/[slug]/_components/observations-rne.tsx
@@ -1,3 +1,4 @@
+import { after } from "next/server";
 import { getRNEObservationsFetcher } from "server-fetch/public";
 import { AsyncDataSectionServer } from "#components/section/data-section/server";
 import { EAdministration } from "#models/administrations/EAdministration";
@@ -7,7 +8,12 @@ import { ObservationsRNEContent } from "./content";
 export const ObservationsRNE: React.FC<{
   uniteLegale: IUniteLegale;
 }> = ({ uniteLegale }) => {
-  const observations = getRNEObservationsFetcher(uniteLegale.siren);
+  const controller = new AbortController();
+  const observations = getRNEObservationsFetcher(uniteLegale.siren, controller);
+
+  after(() => {
+    controller.abort();
+  });
 
   return (
     <AsyncDataSectionServer

--- a/app/(header-default)/dirigeants/[slug]/_component/sections/entreprise/dirigeants-open/section.tsx
+++ b/app/(header-default)/dirigeants/[slug]/_component/sections/entreprise/dirigeants-open/section.tsx
@@ -1,3 +1,4 @@
+import { after } from "next/server";
 import { getDirigeantsRNEFetcher } from "server-fetch/public";
 import { AsyncDataSectionServer } from "#components/section/data-section/server";
 import { EAdministration } from "#models/administrations/EAdministration";
@@ -14,7 +15,12 @@ type IProps = {
  * Dirigeants section
  */
 export default function DirigeantsSection({ uniteLegale }: IProps) {
-  const dirigeants = getDirigeantsRNEFetcher(uniteLegale.siren);
+  const controller = new AbortController();
+  const dirigeants = getDirigeantsRNEFetcher(uniteLegale.siren, controller);
+
+  after(() => {
+    controller.abort();
+  });
 
   return (
     <AsyncDataSectionServer

--- a/app/(header-default)/donnees-financieres/[slug]/_components/finances-association.tsx
+++ b/app/(header-default)/donnees-financieres/[slug]/_components/finances-association.tsx
@@ -1,3 +1,4 @@
+import { after } from "next/server";
 import { getAssociationFromSlugFetcher } from "server-fetch/public";
 import { AsyncDataSectionServer } from "#components/section/data-section/server";
 import { EAdministration } from "#models/administrations/EAdministration";
@@ -15,7 +16,12 @@ export default function FinancesAssociationSection({
 }: {
   uniteLegale: IAssociation;
 }) {
-  const data = getAssociationFromSlugFetcher(uniteLegale.siren);
+  const controller = new AbortController();
+  const data = getAssociationFromSlugFetcher(uniteLegale.siren, controller);
+
+  after(() => {
+    controller.abort();
+  });
 
   return (
     <AsyncDataSectionServer

--- a/clients/api-association/index.ts
+++ b/clients/api-association/index.ts
@@ -20,7 +20,8 @@ import type {
  */
 export async function clientAPIAssociationPublic(
   rnaOrSiren: IdRna | Siren,
-  siretSiege: string
+  siretSiege: string,
+  controller?: AbortController
 ) {
   if (!process.env.API_ASSOCIATION_URL) {
     throw new HttpUnauthorizedError("Missing API Association URL");
@@ -30,6 +31,7 @@ export async function clientAPIAssociationPublic(
 
   const response = await httpGet<IAssociationResponse>(url, {
     timeout: constants.timeout.XXL,
+    signal: controller?.signal,
   });
 
   return mapToDomainObject(response, siretSiege);
@@ -45,7 +47,8 @@ export async function clientAPIAssociationPublic(
  */
 export async function clientAPIAssociationPrivate(
   rnaOrSiren: IdRna | Siren,
-  siretSiege: string
+  siretSiege: string,
+  controller?: AbortController
 ) {
   if (!process.env.API_ASSOCIATION_URL || !process.env.API_ASSOCIATION_KEY) {
     throw new HttpUnauthorizedError("Missing API Association credentials");
@@ -58,6 +61,7 @@ export async function clientAPIAssociationPrivate(
       "X-Gravitee-Api-Key": process.env.API_ASSOCIATION_KEY,
     },
     timeout: constants.timeout.XXL,
+    signal: controller?.signal,
   });
 
   return mapToDomainObject(mapPrivateToPublicResponse(response), siretSiege);

--- a/clients/api-proxy/eori/index.ts
+++ b/clients/api-proxy/eori/index.ts
@@ -8,7 +8,11 @@ import { clientAPIProxy } from "../client";
  * Call EORI to validate a French EORI number
  * @param siret
  */
-export const clientEORI = async (siret: Siret): Promise<IEORIValidation> =>
+export const clientEORI = async (
+  siret: Siret,
+  controller?: AbortController
+): Promise<IEORIValidation> =>
   await clientAPIProxy<IEORIValidation>(routes.proxy.eori(siret), {
     timeout: constants.timeout.XXL,
+    signal: controller?.signal,
   });

--- a/clients/api-proxy/rne/index.ts
+++ b/clients/api-proxy/rne/index.ts
@@ -24,11 +24,15 @@ import type {
  * RNE through the API proxy - API RNE
  * @param siren
  */
-export const clientRNEImmatriculation = async (siren: Siren) => {
+export const clientRNEImmatriculation = async (
+  siren: Siren,
+  controller?: AbortController
+) => {
   const response = await clientAPIProxy<IRNEProxyResponse>(
     routes.proxy.rne.immatriculation.default(siren),
     {
       timeout: constants.timeout.XS,
+      signal: controller?.signal,
     }
   );
   return mapToDomainObject(response);
@@ -38,11 +42,15 @@ export const clientRNEImmatriculation = async (siren: Siren) => {
  * RNE observations through the API proxy - scrapping site as fallback
  * @param siren
  */
-export const clientRNEObservationsFallback = async (siren: Siren) => {
+export const clientRNEObservationsFallback = async (
+  siren: Siren,
+  controller?: AbortController
+) => {
   const response = await clientAPIProxy<IRNEObservationsFallbackProxyResponse>(
     routes.proxy.rne.observations.fallback(siren),
     {
       timeout: constants.timeout.XXXL,
+      signal: controller?.signal,
     }
   );
   return mapObservationsToDomainObject(response);

--- a/clients/api-proxy/tva/index.ts
+++ b/clients/api-proxy/tva/index.ts
@@ -15,7 +15,8 @@ type IVIESResponse = {
  */
 export const clientTVA = async (
   tva: TVANumber,
-  useCache = true
+  useCache = true,
+  controller?: AbortController
 ): Promise<string | null> => {
   let url = routes.proxy.tva(tva);
 
@@ -25,6 +26,7 @@ export const clientTVA = async (
 
   const data = await clientAPIProxy<IVIESResponse>(url, {
     timeout: constants.timeout.XXL,
+    signal: controller?.signal,
   });
 
   return data.tva;

--- a/clients/recherche-entreprise/dirigeants.ts
+++ b/clients/recherche-entreprise/dirigeants.ts
@@ -3,15 +3,19 @@ import type { Siren } from "#utils/helpers";
 import clientSearchRechercheEntreprise from ".";
 
 export const clientDirigeantsRechercheEntreprise = async (
-  siren: Siren
+  siren: Siren,
+  controller?: AbortController
 ): Promise<IDirigeants> => {
-  const { results } = await clientSearchRechercheEntreprise({
-    searchTerms: siren,
-    pageResultatsRecherche: 1,
-    inclureEtablissements: false,
-    inclureImmatriculation: false,
-    pageEtablissements: 1,
-  });
+  const { results } = await clientSearchRechercheEntreprise(
+    {
+      searchTerms: siren,
+      pageResultatsRecherche: 1,
+      inclureEtablissements: false,
+      inclureImmatriculation: false,
+      pageEtablissements: 1,
+    },
+    controller
+  );
 
   if (!results.length || !results[0]) {
     return [];

--- a/clients/recherche-entreprise/index.ts
+++ b/clients/recherche-entreprise/index.ts
@@ -47,14 +47,17 @@ type ClientSearchRechercheEntreprise = {
 /**
  * Get raw results for searchTerms from Sirene open API
  */
-export const clientSearchRechercheEntrepriseRaw = async ({
-  searchTerms,
-  searchFilterParams,
-  inclureEtablissements = false,
-  inclureImmatriculation = false,
-  pageResultatsRecherche = 1,
-  pageEtablissements = 1,
-}: ClientSearchRechercheEntreprise): Promise<ISearchResponse> => {
+export const clientSearchRechercheEntrepriseRaw = async (
+  {
+    searchTerms,
+    searchFilterParams,
+    inclureEtablissements = false,
+    inclureImmatriculation = false,
+    pageResultatsRecherche = 1,
+    pageEtablissements = 1,
+  }: ClientSearchRechercheEntreprise,
+  controller?: AbortController
+): Promise<ISearchResponse> => {
   const encodedTerms = encodeURIComponent(searchTerms);
 
   const route =
@@ -93,6 +96,7 @@ export const clientSearchRechercheEntrepriseRaw = async ({
   const results = await httpGet<ISearchResponse>(url, {
     timeout,
     headers: { referer: "annuaire-entreprises-site" },
+    signal: controller?.signal,
   });
   return results;
 };
@@ -100,22 +104,28 @@ export const clientSearchRechercheEntrepriseRaw = async ({
 /**
  * Get results for searchTerms from Sirene open API and map to domain
  */
-const clientSearchRechercheEntreprise = async ({
-  searchTerms,
-  searchFilterParams,
-  inclureEtablissements = false,
-  inclureImmatriculation = false,
-  pageResultatsRecherche = 1,
-  pageEtablissements = 1,
-}: ClientSearchRechercheEntreprise): Promise<ISearchResults> => {
-  const results = await clientSearchRechercheEntrepriseRaw({
+const clientSearchRechercheEntreprise = async (
+  {
     searchTerms,
     searchFilterParams,
-    inclureEtablissements,
-    inclureImmatriculation,
-    pageResultatsRecherche,
-    pageEtablissements,
-  });
+    inclureEtablissements = false,
+    inclureImmatriculation = false,
+    pageResultatsRecherche = 1,
+    pageEtablissements = 1,
+  }: ClientSearchRechercheEntreprise,
+  controller?: AbortController
+): Promise<ISearchResults> => {
+  const results = await clientSearchRechercheEntrepriseRaw(
+    {
+      searchTerms,
+      searchFilterParams,
+      inclureEtablissements,
+      inclureImmatriculation,
+      pageResultatsRecherche,
+      pageEtablissements,
+    },
+    controller
+  );
 
   if (!results.results || results.results.length === 0) {
     throw new HttpNotFound("No results");

--- a/components/association-section/index.tsx
+++ b/components/association-section/index.tsx
@@ -1,3 +1,4 @@
+import { after } from "next/server";
 import { getAssociationFromSlugFetcher } from "server-fetch/public";
 import { AsyncDataSectionServer } from "#components/section/data-section/server";
 import BreakPageForPrint from "#components-ui/print-break-page";
@@ -14,7 +15,15 @@ const AssociationSection = ({
   uniteLegale: IAssociation;
   session: ISession | null;
 }) => {
-  const association = getAssociationFromSlugFetcher(uniteLegale.siren);
+  const controller = new AbortController();
+  const association = getAssociationFromSlugFetcher(
+    uniteLegale.siren,
+    controller
+  );
+
+  after(() => {
+    controller.abort();
+  });
 
   return (
     <>

--- a/components/eori-cell/index.tsx
+++ b/components/eori-cell/index.tsx
@@ -1,3 +1,4 @@
+import { after } from "next/server";
 import { Suspense } from "react";
 import { getEORIValidationFetcher } from "server-fetch/public";
 import { Loader } from "#components-ui/loader";
@@ -8,7 +9,12 @@ type IProps = {
   siret: Siret;
 };
 export default function EORICell({ siret }: IProps) {
-  const eoriValidation = getEORIValidationFetcher(siret);
+  const controller = new AbortController();
+  const eoriValidation = getEORIValidationFetcher(siret, controller);
+
+  after(() => {
+    controller.abort();
+  });
 
   return (
     <Suspense

--- a/components/tva-cell/index.tsx
+++ b/components/tva-cell/index.tsx
@@ -1,3 +1,4 @@
+import { after } from "next/server";
 import { Suspense } from "react";
 import { buildAndVerifyTVAFetcher } from "server-fetch/public";
 import FAQLink from "#components-ui/faq-link";
@@ -37,7 +38,13 @@ const VerifyTVA: React.FC<{
   siren: Siren;
 }> = async ({ tva: tvaProp, siren }) => {
   const { tvaNumber, mayHaveMultipleTVANumber } = tvaProp;
-  const verification = buildAndVerifyTVAFetcher(siren);
+
+  const controller = new AbortController();
+  const verification = buildAndVerifyTVAFetcher(siren, controller);
+
+  after(() => {
+    controller.abort();
+  });
 
   return (
     <Suspense

--- a/models/tva/verify.ts
+++ b/models/tva/verify.ts
@@ -1,3 +1,4 @@
+import axios from "axios";
 import { clientTVA } from "#clients/api-proxy/tva";
 import { HttpNotFound } from "#clients/exceptions";
 import { EAdministration } from "#models/administrations/EAdministration";
@@ -8,15 +9,26 @@ import {
 import { verifySiren, verifyTVANumber } from "#utils/helpers";
 import { tvaNumber } from "./utils";
 
+// Value returned when the request is aborted
+const ABORTED_VALUE = { tva: null };
+
 export const buildAndVerifyTVA = async (
-  slug: string
+  slug: string,
+  controller?: AbortController
 ): Promise<{ tva: string | null } | IAPINotRespondingError> => {
+  if (controller?.signal.aborted) {
+    return ABORTED_VALUE;
+  }
+
   const siren = verifySiren(slug);
   const tvaNumberFromSiren = verifyTVANumber(tvaNumber(siren));
 
   try {
-    return { tva: await clientTVA(tvaNumberFromSiren) };
+    return { tva: await clientTVA(tvaNumberFromSiren, true, controller) };
   } catch (e: any) {
+    if (axios.isCancel(e)) {
+      return ABORTED_VALUE;
+    }
     if (e instanceof HttpNotFound) {
       return APINotRespondingFactory(EAdministration.VIES, 404);
     }

--- a/server-fetch/middlewares.ts
+++ b/server-fetch/middlewares.ts
@@ -33,6 +33,10 @@ export async function ignoreBot() {
   }
 }
 
+export async function delayFetcher(timeMs: number) {
+  return new Promise((resolve) => setTimeout(resolve, timeMs));
+}
+
 export type Fetcher<Args extends any[], Result> = (
   ...args: Args
 ) => Promise<Result>;

--- a/server-fetch/public/middlewares.ts
+++ b/server-fetch/public/middlewares.ts
@@ -1,5 +1,6 @@
 import type { IDataFetchingState } from "#models/data-fetching";
 import {
+  delayFetcher,
   type Fetcher,
   type IFetcherFactory,
   ignoreBot,
@@ -18,6 +19,8 @@ class PublicFetcherFactory<Args extends any[], Result>
   > {
     return withErrorHandler(async (...args: Args) => {
       await ignoreBot();
+      // Delay the fetcher so that bots fetching HTML pages don't trigger the fetcher
+      await delayFetcher(300);
 
       return this.loader(...args);
     });

--- a/utils/network/backend/error-interceptor.ts
+++ b/utils/network/backend/error-interceptor.ts
@@ -1,4 +1,5 @@
 import type { AxiosError, AxiosResponse } from "axios";
+import axios from "axios";
 import { formatLog } from "../utils/format-log";
 import { httpErrorHandler } from "../utils/http-error-handler";
 
@@ -14,6 +15,10 @@ const getStatus = (response?: AxiosResponse, message?: string) => {
 
 const errorInterceptor = (error: AxiosError) => {
   const { config, response, message } = error || {};
+
+  if (axios.isCancel(error)) {
+    throw error;
+  }
 
   const url = (config?.url || "an unknown url").substring(0, 100);
   const status = getStatus(response, message);

--- a/utils/network/index.ts
+++ b/utils/network/index.ts
@@ -6,6 +6,7 @@ export type IDefaultRequestConfig = {
   method?: "POST" | "GET" | "PATCH" | "PUT" | "DELETE";
   responseType?: "blob" | "arraybuffer" | "stream";
   data?: unknown;
+  signal?: AbortSignal;
 };
 
 /**


### PR DESCRIPTION
Attempts to lower the number of calls to proxy by delaying the streaming of public requests (tva, eori, asso etc...) by 300ms. If the client closes the connection during this delay (or while the request is executing), an abort signal is triggered and stops everything