### PR TITLE
Update Sentry link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Le code source est publié par la Direction interministérielle du numérique so
 
 ## Remontée d'erreur
 
-Nous utilisons [Sentry](https://errors.data.gouv) pour remonter les erreurs du site. Voici les bonnes pratiques à suivre pour remonter une erreur :
+Nous utilisons [Sentry](https://sentry.io/) pour remonter les erreurs du site. Voici les bonnes pratiques à suivre pour remonter une erreur :
 
 1. **Utiliser le bon niveau d'erreur**
 


### PR DESCRIPTION
Erreur : 
bouton lien qui redirige vers : errors.data.gouv.fr  au lieu de : sentry.io

Merci de contribuer à l’Annuaire des Entreprises ! Effacez cette ligne ainsi que, pour chaque ligne ci-dessous, les cas ne correspondant pas à votre contribution :)

- Amélioration technique. | Correction d'un bug. | Changement mineur.
- Zones impactées : `chemin/vers/le/fichier/contenant/les/variables/impactées`.
- Détails :
  - Description de la fonctionnalité ajoutée ou du nouveau comportement adopté.
  - Cas dans lesquels une erreur était constatée.

Surtout, n'hésitez pas à demander de l'aide ! :)
