### PR TITLE
fix(seo): enables legacy qr paths for robots

### DIFF
--- a/src/routes/robots[.]txt.ts
+++ b/src/routes/robots[.]txt.ts
@@ -33,6 +33,7 @@ Allow: /personne/
 Allow: /divers/
 Allow: /erreur/
 Allow: /formulaire/
+Allow: /api/share/qr/
 Disallow: /api/
 Disallow: /admin/
 


### PR DESCRIPTION
Will need to be cleaned after qr pages are correctly de-indexed 